### PR TITLE
Add highlight tags

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -59,15 +59,18 @@ dir README.rdoc
 
 If the file doesn't exist, create it by typing:
 
+<div class="os-specific">
+  <div class="nix">
 {% highlight sh %}
 touch README.rdoc
 {% endhighlight %}
-
-Or if you use a Windows environment, type the following command instead:
-
+  </div>
+  <div class="win">
 {% highlight sh %}
 type nul > README.rdoc
 {% endhighlight %}
+  </div>
+</div>
 
 **COACH:** Talk a little about README.rdoc
 

--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -12,7 +12,7 @@ permalink: github
 
 ## Things you need before you get started
 
-###Git & GitHub
+### Git & GitHub
 
 * Check if Git is installed
 	* In the terminal type `git --version` (1.8 or higher preferred)

--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -34,7 +34,9 @@ On your GitHub profile click "new repo" ![screen shot 2013-06-01 at 12 38 50 pm]
 
 In the command line--make sure you `cd` into your railgirls folder--and type:
 
-`git init`
+{% highlight sh %}
+git init
+{% endhighlight %}
 
 This initializes a git repository in your project
 
@@ -44,26 +46,36 @@ Next check if a file called `READEME.rdoc` exists in your railsgirl directory:
 
 <div class="os-specific">
   <div class="nix">
-    <code>ls README.rdoc</code>
+{% highlight sh %}
+ls README.rdoc
+{% endhighlight %}
   </div>
   <div class="win">
-    <code>dir README.rdoc</code>
+{% highlight sh %}
+dir README.rdoc
+{% endhighlight %}
   </div>
 </div>
 
 If the file doesn't exist, create it by typing:
 
-`touch README.rdoc`
+{% highlight sh %}
+touch README.rdoc
+{% endhighlight %}
 
 Or if you use a Windows environment, type the following command instead:
 
-`type nul > README.rdoc`
+{% highlight sh %}
+type nul > README.rdoc
+{% endhighlight %}
 
 **COACH:** Talk a little about README.rdoc
 
 Then type:
 
-`git status`
+{% highlight sh %}
+git status
+{% endhighlight %}
 
 This will list out all the files in your working directory.
 
@@ -71,19 +83,25 @@ This will list out all the files in your working directory.
 
 Then type:
 
-`git add .`
+{% highlight sh %}
+git add .
+{% endhighlight %}
 
 This adds in all of your files & changes so far to a staging area.
 
 Then type:
 
-`git commit -m "first commit"`
+{% highlight sh %}
+git commit -m "first commit"
+{% endhighlight %}
 
 This commits all of your files, adding the message "first commit"
 
 Next type:
 
-`git remote add origin https://github.com/username/rails-girls.git`
+{% highlight sh %}
+git remote add origin https://github.com/username/rails-girls.git
+{% endhighlight %}
 
 _Your GitHub Repository page will list the repository URL, so feel free to copy and paste from there, rather than typing it in manually. You can copy and paste the link from your GitHub repository page by clicking the clipboard icon next to the URL._
 
@@ -91,7 +109,9 @@ This creates a remote, or _connection_, named "origin" pointing at the GitHub re
 
 Then type:
 
-`git push -u origin master`
+{% highlight sh %}
+git push -u origin master
+{% endhighlight %}
 
 This sends your commits in your "master" branch to GitHub
 
@@ -99,11 +119,11 @@ Congratulations your app is on GitHub! Go check it out by going to the same url 
 
 If you want to continue making changes and pushing them to GitHub you'll just need to use the following three commands:
 
-`git add .`
-
-`git commit -m "type your commit message here"`
-
-`git push origin master`
+{% highlight sh %}
+git add .
+git commit -m "type your commit message here"
+git push origin master
+{% endhighlight %}
 
 ## What's next?
 

--- a/_posts/2013-07-23-bundlerfordevelopment.markdown
+++ b/_posts/2013-07-23-bundlerfordevelopment.markdown
@@ -21,28 +21,37 @@ permalink: bundlerfordevelopment
 
 2. Download a copy of your fork of Bundler
 
-    `$ git clone https://github.com/user_name/bundler.git`
-
+{% highlight sh %}
+git clone https://github.com/user_name/bundler.git
+{% endhighlight %}
 
 3. Change into the Bundler directory
 
-    `$ cd bundler`
+{% highlight sh %}
+cd bundler
+{% endhighlight %}
 
 4. Configure the remote
 
-    `$ git remote add upstream https://github.com/bundler/bundler.git`
+{% highlight sh %}
+git remote add upstream https://github.com/bundler/bundler.git
+{% endhighlight %}
 
     This connects your local repo to the upstream repo at Github.
 
 
 5. Install Bundler development dependencies
 
-    `$ rake spec:deps`
+{% highlight sh %}
+rake spec:deps
+{% endhighlight %}
 
     What is rake? [http://rake.rubyforge.org/](http://rake.rubyforge.org/)
 
 6. Run the Bundler test suite
 
-    `$ rake spec`
+{% highlight sh %}
+rake spec
+{% endhighlight %}
 
     This could take about 15 minutes.

--- a/_posts/2013-07-23-bundlerfordevelopment.markdown
+++ b/_posts/2013-07-23-bundlerfordevelopment.markdown
@@ -6,7 +6,7 @@ permalink: bundlerfordevelopment
 
 # How to Set Up Bundler for Development
 
-1. Fork Bundler
+## *1.*Fork Bundler
 
     Go to the Bundler Github [https://github.com/bundler/bundler](https://github.com/bundler/bundler)
 
@@ -19,19 +19,19 @@ permalink: bundlerfordevelopment
 <br />
 </p>
 
-2. Download a copy of your fork of Bundler
+## *2.*Download a copy of your fork of Bundler
 
 {% highlight sh %}
 git clone https://github.com/user_name/bundler.git
 {% endhighlight %}
 
-3. Change into the Bundler directory
+## *3.*Change into the Bundler directory
 
 {% highlight sh %}
 cd bundler
 {% endhighlight %}
 
-4. Configure the remote
+## *4.*Configure the remote
 
 {% highlight sh %}
 git remote add upstream https://github.com/bundler/bundler.git
@@ -40,7 +40,7 @@ git remote add upstream https://github.com/bundler/bundler.git
     This connects your local repo to the upstream repo at Github.
 
 
-5. Install Bundler development dependencies
+## *5.*Install Bundler development dependencies
 
 {% highlight sh %}
 rake spec:deps
@@ -48,7 +48,7 @@ rake spec:deps
 
     What is rake? [http://rake.rubyforge.org/](http://rake.rubyforge.org/)
 
-6. Run the Bundler test suite
+## *6.*Run the Bundler test suite
 
 {% highlight sh %}
 rake spec

--- a/_posts/2013-07-23-bundlerfordevelopment.markdown
+++ b/_posts/2013-07-23-bundlerfordevelopment.markdown
@@ -8,11 +8,11 @@ permalink: bundlerfordevelopment
 
 ## *1.*Fork Bundler
 
-    Go to the Bundler Github [https://github.com/bundler/bundler](https://github.com/bundler/bundler)
+Go to the Bundler Github [https://github.com/bundler/bundler](https://github.com/bundler/bundler)
 
-    Press the fork button.
+Press the fork button.
 
-    Fork Bundler so you can create pull requests with your changes
+Fork Bundler so you can create pull requests with your changes
 
 <p>
 <img src="../images/fork1.jpg" />
@@ -37,8 +37,7 @@ cd bundler
 git remote add upstream https://github.com/bundler/bundler.git
 {% endhighlight %}
 
-    This connects your local repo to the upstream repo at Github.
-
+This connects your local repo to the upstream repo at Github.
 
 ## *5.*Install Bundler development dependencies
 
@@ -46,7 +45,7 @@ git remote add upstream https://github.com/bundler/bundler.git
 rake spec:deps
 {% endhighlight %}
 
-    What is rake? [http://rake.rubyforge.org/](http://rake.rubyforge.org/)
+What is rake? [http://rake.rubyforge.org/](http://rake.rubyforge.org/)
 
 ## *6.*Run the Bundler test suite
 
@@ -54,4 +53,4 @@ rake spec:deps
 rake spec
 {% endhighlight %}
 
-    This could take about 15 minutes.
+This could take about 15 minutes.

--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -6,7 +6,7 @@ permalink: design-html-css
 
 ## *1.*Design your header
 
-+ put the following code to the bottom of `app/assets/stylesheets/application.css`:
+put the following code to the bottom of `app/assets/stylesheets/application.css`:
 
 {% highlight css %}
 .navbar {
@@ -15,13 +15,11 @@ permalink: design-html-css
 }
 {% endhighlight %}
 
-  Now refresh the page and check the changes. You can try change the
-    color or font of the header. You can check the color reference
-    from [http://color.uisdc.com/](http://color.uisdc.com/).
+Now refresh the page and check the changes. You can try change the color or font of the header. You can check the color reference from [http://color.uisdc.com/](http://color.uisdc.com/).
 
 **Coach:** talk about the property `display`, inline and block element.
 
-+ Then put these lines at the bottom：
+Then put these lines at the bottom：
 
 {% highlight css %}
 .navbar a.brand { font-size: 18px; }
@@ -37,30 +35,27 @@ permalink: design-html-css
 
 ## *2.*Design your table
 
- + We simply use the twitter [Bootstrap](http://getbootstrap.com/) to
-   polish our table. Find this line from
-   app/views/ideas/index.html.erb and replace:
+We simply use the twitter [Bootstrap](http://getbootstrap.com/) to polish our table. Find this line from app/views/ideas/index.html.erb and replace:
 
 {% highlight html %}
 <table>
 {% endhighlight %}
 
-   with
+with
 
 {% highlight html %}
 <table class="table">
 {% endhighlight %}
 
- + Modify size of the picture using the following lines
+Modify size of the picture using the following lines
 
 {% highlight erb %}
 <%= image_tag(idea.picture_url, :width => 600) if idea.picture.present? %>
 {% endhighlight %}
 
-     try to change the width and see what's gonna happen
+try to change the width and see what's gonna happen
 
-
- + add the following lines to the bottom of file app/assets/stylesheets/ideas.css.scss:
+add the following lines to the bottom of file app/assets/stylesheets/ideas.css.scss:
 
 {% highlight css %}
 .container a:hover {
@@ -70,15 +65,11 @@ permalink: design-html-css
 }
 {% endhighlight %}
 
-
- + try add some background style with property `background-image`,
-   reference to
-   [http://subtlepatterns.com/](http://subtlepatterns.com/) for some patterns.
-
+try add some background style with property `background-image`, reference to [http://subtlepatterns.com/](http://subtlepatterns.com/) for some patterns.
 
 ## *3.*add style to footer
 
-+ add the lines to bottom of  app/assets/stylesheets/application.css:
+add the lines to bottom of  app/assets/stylesheets/application.css:
 
 {% highlight css %}
 footer {
@@ -87,15 +78,13 @@ footer {
 }
 {% endhighlight %}
 
-    try put more things into `footer`, then adjust it's position.
+try put more things into `footer`, then adjust it's position.
 
 ## *4.*add style to button
 
-  + open
-    [http://localhost:3000/ideas/new](http://localhost:3000/ideas/new)
-    and find the `Create Idea` button.
+open [http://localhost:3000/ideas/new](http://localhost:3000/ideas/new) and find the `Create Idea` button.
 
-   add these lines to app/assets/stylesheets/ideas.css.scss
+add these lines to app/assets/stylesheets/ideas.css.scss
 
 {% highlight css %}
 .container input[type="submit"] {

--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -4,7 +4,7 @@ title: Add design to your App with HTML and CSS
 permalink: design-html-css
 ---
 
-1.Design your header
+## *1.*Design your header
 
 + put the following code to the bottom of `app/assets/stylesheets/application.css`:
 
@@ -35,7 +35,7 @@ permalink: design-html-css
 **Coach:** explain the 4 states of a link
 
 
-2.Design your table
+## *2.*Design your table
 
  + We simply use the twitter [Bootstrap](http://getbootstrap.com/) to
    polish our table. Find this line from
@@ -76,7 +76,7 @@ permalink: design-html-css
    [http://subtlepatterns.com/](http://subtlepatterns.com/) for some patterns.
 
 
-3.add style to footer
+## *3.*add style to footer
 
 + add the lines to bottom of  app/assets/stylesheets/application.css:
 
@@ -89,7 +89,7 @@ footer {
 
     try put more things into `footer`, then adjust it's position.
 
-4.add style to button
+## *4.*add style to button
 
   + open
     [http://localhost:3000/ideas/new](http://localhost:3000/ideas/new)

--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -8,12 +8,12 @@ permalink: design-html-css
 
 + put the following code to the bottom of `app/assets/stylesheets/application.css`:
 
-    ```
-    .navbar {
-        min-height: 38px;
-      background-color: #f55e55;
-    }
-    ```
+{% highlight css %}
+.navbar {
+  min-height: 38px;
+  background-color: #f55e55;
+}
+{% endhighlight %}
 
   Now refresh the page and check the changes. You can try change the
     color or font of the header. You can check the color reference
@@ -23,14 +23,14 @@ permalink: design-html-css
 
 + Then put these lines at the bottom：
 
-    ```
-    .navbar a.brand { font-size: 18px; }
-    .navbar a.brand:hover {
-     color: #fff;
-     background-color: transparent;
-     text-decoration: none;
-    }
-    ```
+{% highlight css %}
+.navbar a.brand { font-size: 18px; }
+.navbar a.brand:hover {
+ color: #fff;
+ background-color: transparent;
+ text-decoration: none;
+}
+{% endhighlight %}
 
     **Coach: ** explain the 4 states of a link
 
@@ -41,30 +41,34 @@ permalink: design-html-css
    polish our table. Find this line from
    app/views/ideas/index.html.erb and replace:
 
-   `<table>`
+{% highlight html %}
+<table>
+{% endhighlight %}
 
    with
 
-   `<table class="table">`
+{% highlight html %}
+<table class="table">
+{% endhighlight %}
 
  + Modify size of the picture using the following lines
 
-     ```
-     <%= image_tag(idea.picture_url, :width => 600) if idea.picture.present? %>
-     ```
+{% highlight erb %}
+<%= image_tag(idea.picture_url, :width => 600) if idea.picture.present? %>
+{% endhighlight %}
 
      try to change the width and see what's gonna happen
 
 
  + add the following lines to the bottom of file app/assets/stylesheets/ideas.css.scss:
 
-  ```
-  .container a:hover {
-    color: #f55e55;
-    text-decoration: none;
-    background-color: rgba(255, 255, 255, 0);
-  }
-  ```
+{% highlight css %}
+.container a:hover {
+  color: #f55e55;
+  text-decoration: none;
+  background-color: rgba(255, 255, 255, 0);
+}
+{% endhighlight %}
 
 
  + try add some background style with property `background-image`,
@@ -76,12 +80,12 @@ permalink: design-html-css
 
 + add the lines to bottom of  app/assets/stylesheets/application.css:
 
-    ```
-    footer {
-      background-color: #ebebeb;
-      padding: 30px 0;
-    }
-    ```
+{% highlight css %}
+footer {
+  background-color: #ebebeb;
+  padding: 30px 0;
+}
+{% endhighlight %}
 
     try put more things into `footer`, then adjust it's position.
 
@@ -93,15 +97,15 @@ permalink: design-html-css
 
    add these lines to app/assets/stylesheets/ideas.css.scss
 
-   ```
-   .container input[type="submit"] {
-      height: 30px;
-      font-size: 13px;
-      background-color: #f55e55;
-      border: none;
-      color: #fff;
-    }
-   ```
+{% highlight css %}
+.container input[type="submit"] {
+  height: 30px;
+  font-size: 13px;
+  background-color: #f55e55;
+  border: none;
+  color: #fff;
+}
+{% endhighlight %}
 
    **Coach** explain how to use `border` in css, try modify the style
      of button like round the corner, add shadow or color etc.

--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -17,8 +17,6 @@ put the following code to the bottom of `app/assets/stylesheets/application.css`
 
 Now refresh the page and check the changes. You can try change the color or font of the header. You can check the color reference from [http://color.uisdc.com/](http://color.uisdc.com/).
 
-**Coach:** talk about the property `display`, inline and block element.
-
 Then put these lines at the bottom：
 
 {% highlight css %}

--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -19,7 +19,7 @@ permalink: design-html-css
     color or font of the header. You can check the color reference
     from [http://color.uisdc.com/](http://color.uisdc.com/).
 
-    **Coach: ** talk about the property `display`, inline and block element.
+**Coach:** talk about the property `display`, inline and block element.
 
 + Then put these lines at the bottom：
 
@@ -32,7 +32,7 @@ permalink: design-html-css
 }
 {% endhighlight %}
 
-    **Coach: ** explain the 4 states of a link
+**Coach:** explain the 4 states of a link
 
 
 2.Design your table
@@ -107,5 +107,4 @@ footer {
 }
 {% endhighlight %}
 
-   **Coach** explain how to use `border` in css, try modify the style
-     of button like round the corner, add shadow or color etc.
+**Coach:** explain how to use `border` in css, try modify the style of button like round the corner, add shadow or color etc.

--- a/_posts/2014-05-29-touristic-autism_intro.markdown
+++ b/_posts/2014-05-29-touristic-autism_intro.markdown
@@ -73,41 +73,57 @@ Rails has some facilities to help you recover from mistakes.
 
 For instance, you may decide to change the name of a controller. Since, when generating a controller, Rails creates many more files than the controller file itself, undoing the generation means removing a whole set of files. In Rails, this can be accomplished with rails destroy. In particular, these two commands cancel each other out:
 
-  $ rails generate controller FooBars baz quux
-  $ rails destroy  controller FooBars baz quux
+{% highlight sh %}
+rails generate controller FooBars baz quux
+rails destroy  controller FooBars baz quux
+{% endhighlight %}
 
 Similarly, after we generate a model as follows:
 
-  $ rails generate model Foo bar:string baz:integer
+{% highlight sh %}
+rails generate model Foo bar:string baz:integer
+{% endhighlight %}
 
 This can be undone using
 
-  $ rails destroy model Foo
-
+{% highlight sh %}
+rails destroy model Foo
+{% endhighlight %}
 
 Migrations change the state of the database using
 
-  $ rake db:migrate
+{% highlight sh %}
+rake db:migrate
+{% endhighlight %}
 
 We can undo a single migration step using
 
-  $ rake db:rollback
+{% highlight sh %}
+rake db:rollback
+{% endhighlight %}
 
 To go all the way back to the beginning, we can use
 
-  $ rake db:migrate VERSION=0
+{% highlight sh %}
+rake db:migrate VERSION=0
+{% endhighlight %}
 
 As you might guess, substituting any other number for 0 migrates to that version number, where the version numbers come from listing the migrations sequentially.
 
 To drop a table from the db enter
 
-  $ rails console
+{% highlight sh %}
+rails console
+{% endhighlight %}
 
 Then just type:
 
-  >> ActiveRecord::Migration.drop_table(:<table-name>)
+{% highlight ruby %}
+ActiveRecord::Migration.drop_table(:<table-name>)
+{% endhighlight %}
 
 You can browse directly the database (if sqlite3 type ".quit" to exit afterwards) by typing
 
-  $ rails db
-
+{% highlight sh %}
+rails db
+{% endhighlight %}

--- a/_posts/2014-05-29-touristic-autism_intro.markdown
+++ b/_posts/2014-05-29-touristic-autism_intro.markdown
@@ -27,8 +27,8 @@ The basic guides that have been merged and adapted are the [Ruby on Rails Tutori
 **Make sure you have Rails and Git installed.** [**Follow the installation guide**](/install), the [**Installing Git section of Pro Git**](http://www.git-scm.com/book/en/Getting-Started-Installing-Git) to get set up. Then configure GitHub by typing the following in your terminal:
 
 {% highlight sh %}
-$ git config --global user.name "Your Name"
-$ git config --global user.email your.email@example.com
+git config --global user.name "Your Name"
+git config --global user.email your.email@example.com
 {% endhighlight %}
 
 <p>one-time setup steps for GitHub.</p>


### PR DESCRIPTION
There is not highlight tags on the following those pages. I changed page layout.

http://guides.railsgirls.com/github
http://guides.railsgirls.com/design-html-css
http://guides.railsgirls.com/bundlerfordevelopment
http://guides.railsgirls.com/touristic-autism_intro

the type command description for Windows changed to use `.os-specific` class.

the property `display` description not exist in `_posts/2014-01-05-design-using-html-and-css.markdown`. So I removed tip. 
