### PR TITLE
Windows install troubleshooting

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -171,10 +171,10 @@ gem -v
 If it is lower than `2.2.3` you will need to manually update it:
 
 
-First download the [ruby-gems-update gem](https://github.com/rubygems/rubygems/releases/download/v2.2.3/rubygems-update-2.2.3.gem). Move the file to `c:\\rubygems-update-2.2.3.gem` then run:
+First download the [ruby-gems-update gem](https://rubygems.org/gems/rubygems-update-2.6.7.gem). Move the file to `c:\\rubygems-update-2.6.7.gem` then run:
 
 {% highlight sh %}
-gem install --local c:\\rubygems-update-2.2.3.gem
+gem install --local c:\\rubygems-update-2.6.7.gem
 update_rubygems --no-document
 gem uninstall rubygems-update -x
 {% endhighlight %}
@@ -185,8 +185,9 @@ Check your version of rubygems
 gem -v
 {% endhighlight %}
 
-Make sure it is equal or higher than `2.2.3`. Re-run the command that was failing previously.
+Make sure it is equal or higher than `2.6.7`. Re-run the command that was failing previously.
 
+If you are still running into problems you can always find the latest version of rubygems online at [rubygems.org](https://rubygems.org/pages/download). If you click on **GEM** you will get the latest version.
 
 ### 'x64_mingw' is not a valid platform` Error
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -193,7 +193,7 @@ If you are still running into problems you can always find the latest version of
 
 The `Gem::RemoteFetcher::FetchError: SSL_connect` can also occur during the `bundle install` stage when creating a new rails app.
 
-The error will make mention of [bit.ly/ruby-ssl](http://bit.ly/ruby-ssl). What is relevant for Windows users at this point is [this GitHub gist](https://gist.github.com/867550). The described manual way has proven to be succesful to solve the `bundle install` eror.
+The error will make mention of [bit.ly/ruby-ssl](http://bit.ly/ruby-ssl). What is relevant for Windows users at this point is [this GitHub gist](https://gist.github.com/867550). The described manual way has proven to be succesful to solve the `bundle install` error.
 
 ### 'x64_mingw' is not a valid platform` Error
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -189,6 +189,12 @@ Make sure it is equal or higher than `2.6.7`. Re-run the command that was failin
 
 If you are still running into problems you can always find the latest version of rubygems online at [rubygems.org](https://rubygems.org/pages/download). If you click on **GEM** you will get the latest version.
 
+### During bundle install
+
+The `Gem::RemoteFetcher::FetchError: SSL_connect` can also occur during the `bundle install` stage when creating a new rails app.
+
+The error will make mention of [bit.ly/ruby-ssl](http://bit.ly/ruby-ssl). What is relevant for Windows users at this point is [this GitHub gist](https://gist.github.com/867550). The described manual way has proven to be succesful to solve the `bundle install` eror.
+
 ### 'x64_mingw' is not a valid platform` Error
 
 Sometimes you get the following error when running `rails server`:


### PR DESCRIPTION
During the install all Windows machines appeared to run into the same problems. One was related to `rubygems-update` versioning and the other had to do with `bundle install`.

The fix for both of these problems are updated and described here.