### PR TITLE
Add instruction to commit Gemfile change

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -55,6 +55,9 @@ end
 
 Run `bundle install --without production` to setup your dependencies.
 
+Don't forget to do `git add .` and `git commit -m "Use postgres as production database"`
+in order to add this change to your master branch before pushing to heroku later.
+
 __COACH__: You can talk about RDBMS and the different ones out there, plus
 include some details on Heroku's dependency on PostgreSQL.
 


### PR DESCRIPTION
During the Rails Girls event in Rotterdam today, we had a lot of girls who ran into this issue: they carefully followed the heroku deploy instructions, but the deploy wouldn't work because the change to the Gemfile to use postgres hadn't been committed.
I propose to add this sentence as a pointer.