### PR TITLE
Remove explicit "multipart: true" from App Tutorial

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -322,20 +322,6 @@ to
 <%= f.file_field :picture %>
 {% endhighlight %}
 
-Sometimes, you might get an *TypeError: can't cast ActionDispatch::Http::UploadedFile to string*.
-
-If this happens, in file `app/views/ideas/_form.html.erb` change the line
-
-{% highlight erb %}
-<%= form_for(idea) do |f| %>
-{% endhighlight %}
-
-to
-
-{% highlight erb %}
-<%= form_for(idea, html: {multipart: true}) do |f| %>
-{% endhighlight %}
-
 In your browser, add new idea with a picture. When you upload a picture it doesn't look nice because it only shows a path to the file, so let's fix that.
 
 Open `app/views/ideas/show.html.erb` and change


### PR DESCRIPTION
This should no longer be necessary. As per [Rails documentation](http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-file_field):

> Using this method inside a form_for block will set the enclosing form's encoding to multipart/form-data.