### PR TITLE
Update Rails to 5.1.1 for installing on windows

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -164,7 +164,7 @@ This can happen when the installer cannot correctly setup the paths required to 
 It's nothing serious, we can fix this in different ways but the easiest is by manually installing the rails gem with the following command:
 
 {% highlight sh %}
-gem install rails --no-document
+gem install rails bundler --no-document
 {% endhighlight %}
 
 This will (re)install rails correctly and running:
@@ -176,10 +176,10 @@ rails -v
 Should print the currently installed rails version number (your version may differ):
 
 {% highlight sh %}
-Rails 5.0.2
+Rails 5.1.1
 {% endhighlight %}
 
-If the Rails version is less than 5, update it using a following command:
+If the Rails version is less than 5.1, update it using a following command:
 
 {% highlight sh %}
 gem update rails --no-document


### PR DESCRIPTION
Update to adopt Rails 5.1.1 on windows.

- Add "gem install bundler" to fix a railsinstaller3.3.0 bug
- No need to change in Mac

We check it runs good for installing, creating app in /app page and deploying to heroku in the RailsGirls Takasaki event.

