### PR TITLE
Below row `x` instead of after row `x`

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -25,7 +25,7 @@ rake db:migrate
 
 You need to make sure that Rails knows the relation between objects (ideas and comments).
 As one idea can have many comments we need to make sure the idea model knows that.
-Open app/models/idea.rb and after the row
+Open app/models/idea.rb and below the row
 {% highlight ruby %}
 class Idea < ActiveRecord::Base
 {% endhighlight %}
@@ -34,7 +34,7 @@ add
 has_many :comments
 {% endhighlight %}
 
-The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and after
+The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and below
 {% highlight ruby %}
 class Comment < ActiveRecord::Base
 {% endhighlight %}


### PR DESCRIPTION
My students were confused by adding something _after_ a given line and we ended up with code like this:
```
class Question < ApplicationRecord has_many :answers
end
```
instead of:
```
class Question < ApplicationRecord
  has_many :answers
end
```

Hopefully, this copy change helps to mitigate this mistake
