### PR TITLE
Removes the dollar sign command prefixes

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -25,7 +25,7 @@ rails db:migrate
 
 You need to make sure that Rails knows the relation between objects (ideas and comments).
 As one idea can have many comments we need to make sure the idea model knows that.
-Open app/models/idea.rb and after the row
+Open app/models/idea.rb and below the row
 {% highlight ruby %}
 class Idea < ApplicationRecord
 {% endhighlight %}
@@ -34,7 +34,7 @@ add
 has_many :comments
 {% endhighlight %}
 
-The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and after
+The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and below
 {% highlight ruby %}
 class Comment < ApplicationRecord
 {% endhighlight %}

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -25,7 +25,7 @@ rake db:migrate
 
 You need to make sure that Rails knows the relation between objects (ideas and comments).
 As one idea can have many comments we need to make sure the idea model knows that.
-Open app/models/idea.rb and below the row
+Open app/models/idea.rb and after the row
 {% highlight ruby %}
 class Idea < ActiveRecord::Base
 {% endhighlight %}
@@ -34,7 +34,7 @@ add
 has_many :comments
 {% endhighlight %}
 
-The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and below
+The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and after
 {% highlight ruby %}
 class Comment < ActiveRecord::Base
 {% endhighlight %}

--- a/_posts/2016-08-30-activeadmin.markdown
+++ b/_posts/2016-08-30-activeadmin.markdown
@@ -22,28 +22,32 @@ gem 'inherited_resources', github: 'activeadmin/inherited_resources'
 {% endhighlight %}
 and run
 {% highlight sh %}
-$ bundle install
+bundle install
 {% endhighlight %}
 to install the gems.
 
 After updating your bundle, run the installer
 {% highlight sh %}
-$ rails generate active_admin:install
+rails generate active_admin:install
 {% endhighlight %}
 
 The installer creates an initializer used for configuring defaults used by Active Admin as well as a new folder at app/admin to put all your admin configurations.
 
 Migrate your db and start the server:
 {% highlight sh %}
-$ rake db:migrate
-$ rails server
+rake db:migrate
+rails server
 {% endhighlight %}
 
 ## Creating your first admin account
 Open up the Rails console and create your new user via the `AdminUser` model:
 {% highlight sh %}
-$ rails console
-irb(main):001:0> AdminUser.create(:email => 'admin@railsgirls.com', :password => 'password123', :password_confirmation => 'password123')
+rails console
+{% endhighlight %}
+
+Once booted (the terminal shows `irb(main):001:0>`), you can run this command:
+{% highlight sh %}
+AdminUser.create(:email => 'admin@railsgirls.com', :password => 'password123', :password_confirmation => 'password123')
 {% endhighlight %}
 
 You should see something like:
@@ -66,7 +70,7 @@ Voila! You're on your brand new Active Admin dashboard.
 ## Add "Ideas" to back-end
 To register your `Idea` model with Active Admin, run:
 {% highlight sh %}
-$ rails generate active_admin:resource Idea
+rails generate active_admin:resource Idea
 {% endhighlight %}
 Refresh your admin page and you will find [Ideas](http://localhost:3000/admin/ideas) in the navigation.
 


### PR DESCRIPTION
My students copied pasted the commands including the `$` sign, which results in an error. To be consistent with the other tutorials, we've removed these prefixes.