### PR TITLE
Rails 5 updates

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -18,7 +18,7 @@ rails g scaffold comment user_name:string body:text idea_id:integer
 {% endhighlight %}
 This will create a migration file that lets your database know about the new comments table. Run the migrations using
 {% highlight sh %}
-rake db:migrate
+rails db:migrate
 {% endhighlight %}
 
 ## *2.*Add relations to models

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -27,7 +27,7 @@ You need to make sure that Rails knows the relation between objects (ideas and c
 As one idea can have many comments we need to make sure the idea model knows that.
 Open app/models/idea.rb and below the row
 {% highlight ruby %}
-class Idea < ActiveRecord::Base
+class Idea < ApplicationRecord
 {% endhighlight %}
 add
 {% highlight ruby %}
@@ -36,7 +36,7 @@ has_many :comments
 
 The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and below
 {% highlight ruby %}
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
 {% endhighlight %}
 
 add the row

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -25,7 +25,7 @@ rake db:migrate
 
 You need to make sure that Rails knows the relation between objects (ideas and comments).
 As one idea can have many comments we need to make sure the idea model knows that.
-Open app/models/idea.rb and after the row
+Open app/models/idea.rb and below the row
 {% highlight ruby %}
 class Idea < ActiveRecord::Base
 {% endhighlight %}
@@ -34,7 +34,7 @@ add
 has_many :comments
 {% endhighlight %}
 
-The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and after
+The comment also has to know that it belongs to an idea. So open `app/models/comment.rb` and below
 {% highlight ruby %}
 class Comment < ActiveRecord::Base
 {% endhighlight %}

--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -72,7 +72,7 @@ Do the same for `app/views/comments/show.html.erb`. These lines are not necessar
 We'll use a bundled generator script to create the User model.
 {% highlight sh %}
    rails g devise user
-   rake db:migrate
+   rails db:migrate
 {% endhighlight %}
 
 **Coach:** Explain what user model has been generated. What are the

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -402,7 +402,7 @@ In the 'New Workspace' view, a few settings have to be made.
 * At the bottom, you find the terminal where you can run commands
 * Everything you need is right here in you browser window - you do not need to start an editor or terminal anywhere else
 * If you are following a guide or tutorial, use the commands for Linux even if you are on a Windows computer - your operating system does not matter, since all commands are run on your project's machine in the cloud, which is running Linux
-* If a guide or tutorial asks you to run a rails command that contains `rails` or `rake`, prepend `bundle exec` to this command, e. g. `bundle exec rake db:migrate`. Exception: the `rails new` command is not prefixed.
+* If a guide or tutorial asks you to run a rails command that contains `rails` or `rake`, prepend `bundle exec` to this command, e. g. `bundle exec rails db:migrate`. Exception: the `rails new` command is not prefixed.
 * If a guide or tutorial asks you to start the rails server with `rails server` or `rails s`, append `-b 0.0.0.0` to this command so that you run `rails server -b 0.0.0.0`
 * If a guide or tutorial asks you to point your browser to something like `http://localhost:3000`, follow these instructions instead:
 

--- a/_posts/2013-08-12-guide-to-the-guide.markdown
+++ b/_posts/2013-08-12-guide-to-the-guide.markdown
@@ -139,7 +139,7 @@ As we’ve already discussed, a model can have attributes (properties) represent
 
 Migrations change the state of the database. When you run the `scaffold` command, a migration file containing instructions for the database table relevant to your command is added to the `db/migrate` folder of your application. For example, when you ran the `rails generate scaffold` command, a migration containing instructions for our ideas table was created. There are other commands that create migrations such as the `rails generate model` command and the `rails generate migration` command.
 
-The `rails db:migrate` command updates the database according to the specifications in the migration file. This command, known as “migrating up”, ensures that your idea model is added to the database. Migrations can also be undone (“migrating down”) using the command `rake db:rollback`.
+The `rails db:migrate` command updates the database according to the specifications in the migration file. This command, known as “migrating up”, ensures that your idea model is added to the database. Migrations can also be undone (“migrating down”) using the command `rails db:rollback`.
 
 ## <a id="3_design">*3.* Design</a>
 In a Ruby on Rails application, the user interface (what someone visiting the website will see), is often written in HTML with Embedded Ruby (ERB) code. This code is contained in a specific directory called ‘views’, located in the `app` folder of your Rails application directory.

--- a/_posts/2013-08-12-guide-to-the-guide.markdown
+++ b/_posts/2013-08-12-guide-to-the-guide.markdown
@@ -139,7 +139,7 @@ As we’ve already discussed, a model can have attributes (properties) represent
 
 Migrations change the state of the database. When you run the `scaffold` command, a migration file containing instructions for the database table relevant to your command is added to the `db/migrate` folder of your application. For example, when you ran the `rails generate scaffold` command, a migration containing instructions for our ideas table was created. There are other commands that create migrations such as the `rails generate model` command and the `rails generate migration` command.
 
-The `rake db:migrate` command updates the database according to the specifications in the migration file. This command, known as “migrating up”, ensures that your idea model is added to the database. Migrations can also be undone (“migrating down”) using the command `rake db:rollback`.
+The `rails db:migrate` command updates the database according to the specifications in the migration file. This command, known as “migrating up”, ensures that your idea model is added to the database. Migrations can also be undone (“migrating down”) using the command `rake db:rollback`.
 
 ## <a id="3_design">*3.* Design</a>
 In a Ruby on Rails application, the user interface (what someone visiting the website will see), is often written in HTML with Embedded Ruby (ERB) code. This code is contained in a specific directory called ‘views’, located in the `app` folder of your Rails application directory.

--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -329,7 +329,7 @@ This is needed for the app to load the added library.
 Open `app/models/idea.rb` and under the line
 
 {% highlight ruby %}
-class Idea < ActiveRecord::Base
+class Idea < ApplicationRecord
 {% endhighlight %}
 
 add

--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -191,14 +191,14 @@ The scaffold creates new files in your project directory, but to get it to work 
 <div class="os-specific">
   <div class="nix">
 {% highlight sh %}
-rake db:migrate
+rails db:migrate
 rails server
 {% endhighlight %}
   </div>
 
   <div class="win">
 {% highlight sh %}
-rake db:migrate
+rails db:migrate
 ruby bin\rails server
 {% endhighlight %}
   </div>

--- a/_posts/2014-05-29-touristic-autism_intro.markdown
+++ b/_posts/2014-05-29-touristic-autism_intro.markdown
@@ -93,7 +93,7 @@ rails destroy model Foo
 Migrations change the state of the database using
 
 {% highlight sh %}
-rake db:migrate
+rails db:migrate
 {% endhighlight %}
 
 We can undo a single migration step using
@@ -105,7 +105,7 @@ rake db:rollback
 To go all the way back to the beginning, we can use
 
 {% highlight sh %}
-rake db:migrate VERSION=0
+rails db:migrate VERSION=0
 {% endhighlight %}
 
 As you might guess, substituting any other number for 0 migrates to that version number, where the version numbers come from listing the migrations sequentially.

--- a/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
+++ b/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
@@ -78,7 +78,7 @@ right above
 We'll use a bundled generator script to create the User model.
 {% highlight sh %}
    rails g devise user
-   rake db:migrate
+   rails db:migrate
 {% endhighlight %}
 
 **Coach:** Explain what user model has been generated. What are the fields? Note that a model inherits abilities to interact with the DB from its ApplicationRecord super-class (ref. MVC). 
@@ -140,13 +140,13 @@ We are already using a database (see `gem 'sqlite'` in your Gemfile). Let's add 
 <div class="os-specific">
   <div class="nix">
 {% highlight sh %}
-bin/rake db:migrate
+bin/rails db:migrate
 {% endhighlight %}
   </div>
 
   <div class="win">
 {% highlight sh %}
-ruby bin/rake db:migrate
+ruby bin/rails db:migrate
 {% endhighlight %}
   </div>
 
@@ -273,7 +273,7 @@ Just as well as we created a "place" resource and associated it with users, we c
   <div class="nix">
 {% highlight sh %}
 rails generate scaffold comment body:text user_id:integer place_id:integer
-bin/rake db:migrate
+bin/rails db:migrate
 {% endhighlight %}
   </div>
 Start the server, check out the new service in your browser. Then, add-commit-push to github.

--- a/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
+++ b/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
@@ -81,7 +81,7 @@ We'll use a bundled generator script to create the User model.
    rake db:migrate
 {% endhighlight %}
 
-**Coach:** Explain what user model has been generated. What are the fields? Note that a model inherits abilities to interact with the DB from its ActiveRecord::Base super-class (ref. MVC). 
+**Coach:** Explain what user model has been generated. What are the fields? Note that a model inherits abilities to interact with the DB from its ApplicationRecord super-class (ref. MVC). 
 
 ## Step 4: Create your first user
 
@@ -195,7 +195,7 @@ You need to make sure that Rails knows the relation between the User and Place r
 As one user can create many places we need to make sure the user model knows that. 
 Open app/models/user.rb and after the row
 {% highlight ruby %}
-class User < ActiveRecord::Base
+class User < ApplicationRecord
 {% endhighlight %}
 add
 {% highlight ruby %}
@@ -204,7 +204,7 @@ has_many :places
 
 The place also has to know that it belongs to a user. So open app/models/place.rb and after
 {% highlight ruby %}
-class Place < ActiveRecord::Base
+class Place < ApplicationRecord
 {% endhighlight %}
 
 add the row
@@ -298,7 +298,7 @@ has_many :comments
 
 Open app/models/comment.rb and after
 {% highlight ruby %}
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
 {% endhighlight %}
 
 add the rows

--- a/_posts/2014-10-05-diary-app.markdown
+++ b/_posts/2014-10-05-diary-app.markdown
@@ -207,7 +207,7 @@ __COACH__: Explain what models are and the `field:type` notation for generating 
 
 ### Migrate the database
 
-Run `rake db:migrate` to migrate the database so that its structure contains a table for entries.
+Run `rails db:migrate` to migrate the database so that its structure contains a table for entries.
 
 __COACH__: Explain what databases are (in abstract terms, as vessels for storing our application’s data and providing model structures) and why they are needed. Explain that things which are in memory won’t get persisted by default and they need to be persisted explicitly to be available on the next request.
 

--- a/_posts/2016-08-30-activeadmin.markdown
+++ b/_posts/2016-08-30-activeadmin.markdown
@@ -35,7 +35,7 @@ The installer creates an initializer used for configuring defaults used by Activ
 
 Migrate your db and start the server:
 {% highlight sh %}
-$ rake db:migrate
+$ rails db:migrate
 $ rails server
 {% endhighlight %}
 


### PR DESCRIPTION
- db:migrate is a rails command now
- models inherit from ApplicationRecord instead of ActiveRecord::Base