### PR TITLE
Also include jQuery through a script tag

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -241,6 +241,7 @@ and before `</body>` add
     Rails Girls <%= Time.now.year %>
   </div>
 </footer>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.js"></script>
 {% endhighlight %}
 


### PR DESCRIPTION
I think that the latest version of Rails no longer comes with jQuery packaged out of the box, running the app tutorial on latest Rails now shows this error in the console:

```
Uncaught Error: Bootstrap requires jQuery
```

Therefor I figured we also have to add jQuery from a CDN.