### PR TITLE
Fixes the instruction to what Rails 5.1 generates

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -323,13 +323,13 @@ mount_uploader :picture, PictureUploader
 Open `app/views/ideas/_form.html.erb` and change
 
 {% highlight erb %}
-<%= f.text_field :picture %>
+<%= form.text_field :picture, id: :idea_picture  %>
 {% endhighlight %}
 
 to
 
 {% highlight erb %}
-<%= f.file_field :picture, id: :idea_picture %>
+<%= form.file_field :picture, id: :idea_picture %>
 {% endhighlight %}
 
 In your browser, add new idea with a picture. When you upload a picture it doesn't look nice because it only shows a path to the file, so let's fix that.

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -74,21 +74,21 @@ In `app/controllers/ideas_controller.rb` add to the show action
 Open `app/views/comments/_form.html.erb` and after
 {% highlight erb %}
   <div class="field">
-    <%= f.label :body %><br>
-    <%= f.text_area :body %>
+    <%= form.label :body %><br>
+    <%= form.text_area :body %>
   </div>
 {% endhighlight %}
 
 add the row
 {% highlight erb %}
-<%= f.hidden_field :idea_id %>
+<%= form.hidden_field :idea_id %>
 {% endhighlight %}
 
 next, remove
 {% highlight erb %}
 <div class="field">
-  <%= f.label :idea_id %><br>
-  <%= f.number_field :idea_id %>
+  <%= form.label :idea_id %><br>
+  <%= form.number_field :idea_id %>
 </div>
 {% endhighlight %}
 


### PR DESCRIPTION
During the Workshop in Frankfurt nearly all of the participants came across this "problem".

The current scaffold does not use `f` as the variable for the form anymore, instead it uses the more expressive `form` ;)

This fixes the tutorial.