### PR TITLE
Small improvements over guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle/
 _site/
 .DS_Store
+*.swp

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -65,7 +65,7 @@ add
 <%= render partial: 'comments/form', locals: { comment: @comment } %>
 {% endhighlight %}
 
-In `app/controllers/ideas_controller.rb` add to the show action
+In `app/controllers/ideas_controller.rb` add to the show method
 {% highlight ruby %}
 @comments = @idea.comments.all
 @comment = @idea.comments.build

--- a/_posts/2014-01-30-testing.markdown
+++ b/_posts/2014-01-30-testing.markdown
@@ -33,7 +33,14 @@ bundle install
 {% endhighlight %}
 to install the gem.
 
-Finally create the `/spec` directory, where your tests will reside:
+Next create the `spec/` directory inside your application:
+
+{% highlight sh %}
+mkdir spec/
+{% endhighlight %}
+
+The `spec/` directory is where your tests will reside. Finally run the following command:
+
 {% highlight sh %}
 rails generate rspec:install
 {% endhighlight %}
@@ -54,7 +61,7 @@ We will be creating a test for ou `idea` model, to do that in the elegant way in
 
 * Create a `models` folder in your `spec` folder, by running in the terminal:
 {% highlight sh %}
-mkdir /spec/models
+mkdir spec/models
 {% endhighlight %}
 
 * Save your test as `idea_spec.rb` (`<model_name>_spec.rb`).
@@ -64,9 +71,9 @@ Inside that new file, in our first test we will want to guarantee that an idea h
 {% highlight ruby %}
 require "rails_helper"
 
-RSpec.describe Idea, :type => :model do
+RSpec.describe Idea, type: :model do
   it "has a name" do
-    pending
+    skip
   end
 end
 {% endhighlight %}
@@ -82,7 +89,9 @@ __COACH__: Talk about googling terminal output.
 
 Let's do something about that!
 {% highlight ruby %}
-describe Idea do
+require "rails_helper"
+
+RSpec.describe Idea, type: :model do
   it "has a name" do # yep, you can totally use 'it'
     idea = Idea.create!(name: "My Awesome Idea Name") # creating a new idea 'instance'
     expect(idea.name).to eq("My Awesome Idea Name") # this is our expectation
@@ -97,7 +106,9 @@ should give you a more satisfying output.
 You could actually also create two ideas, to be sure that our project is creating ideas in the right way:
 
 {% highlight ruby %}
-describe Idea do
+require "rails_helper"
+
+RSpec.describe Idea, type: :model do
   it "has a name" do # yep, you can totally use 'it'
     idea = Idea.create!(name: "My Awesome Idea Name") # creating a new idea 'instance'
     second_idea = Idea.create!(name: "My Second Idea Name") # creating another new idea 'instance'


### PR DESCRIPTION

A RailsGirls workshop was organized on the last Gitlab Summit 🎉 . From there we received some feedback for the guides, hence this pull request. 

### Changelog

- **Commenting Guide:** One of the struggles that multiple attendees had, was to realize that 
'action' in the controller is actually a 'method'. Hopefully doing this minor wording changing will improve the experience for future attendees. 

- **Testing Guide:** Modifies guide to use `skip` instead of `pending`. As RSpec 3.x pending specs are actually run, and if they pass they're considered a failure, so the output (failure) was a bit confusing. More info: http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#changes_to__semantics_and_introduction_of_

- **Testing Guide:** Fixes some `mkdir` commands to use a relative path (`mkdir spec/`) vs an absolute path (`mkdir /spec/`). 