### PR TITLE
Changed the order of additional guides in app tutorial

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -407,16 +407,23 @@ Now you can open the file `app/views/pages/info.html.erb` and add information ab
 * Add picture resizing to make loading the pictures faster
 
 
-## Additional Guides
+## Other Guides
 
-* Guide 0: [Handy cheatsheet for Ruby, Rails, console etc.](http://www.pragtob.info/rails-beginner-cheatsheet/)
-* Guide 1: [Add commenting by Janika Liiv](/commenting)
-* Guide 2: [Put your app online with Heroku by Terence Lee](/heroku) / [Put your app online with OpenShift by Katie Miller](/openshift) / [Put your app online with anynines](/anynines) / [Put your app online with Trucker.io](/trucker)
-* Guide 3: [Create thumbnail images for the uploads by Miha Filej](/thumbnails)
-* Guide 4: [Add design using HTML &amp; CSS by Alex Liao](/design)
-* Guide 5: [Add Authentication (user accounts) with Devise by Piotr Steininger](/devise)
-* Guide 6: [Adding profile pictures with Gravatar](/gravatar)
-* Guide 7: [Test your app with RSpec](/testing-rspec)
-* Guide 8: [Continuous Deployment with Travis-CI](/continuous-travis) / [Continuous Deployment with Codeship](/continuous) / [Continuous Deployment with Snap CI](/continuous-snap-ci)
-* Guide 9: [Go through additional explanations for the App by Lucy Bain](https://github.com/lbain/railsgirls)
-* Guide 10: [Adding a back-end with Active Admin](/backend-with-active-admin)
+* [Handy cheatsheet for Ruby, Rails, console etc.](http://www.pragtob.info/rails-beginner-cheatsheet/)
+* Guide 1: [Guide to install Rails](/install) (You probably already did this one!)
+* Guide 2: [Build Your First App](/app) (This current page!)
+* Guide 3: [Push Your App to GitHub](/github)
+* Guide 4: Put your app online with...
+    * [Heroku](/heroku) / [OpenShift](/openshift) / [anynines](/anynines) / [Engine Yard](/engineyard) / [prepare for deployment with Phusion Passenger](/passenger)
+* Guide 5: [Allow Comments on Your App](/commenting)
+* Guide 6: [Add design using HTML &amp; CSS](/design)
+* Guide 7: [Create thumbnails with Carrierwave](/thumbnails)
+* Guide 8: [Add Authentication (user accounts) with Devise](/devise)
+* Guide 9: [Add Profile Pics with Gravatar](/gravatar)
+* Guide 10: [Improve your design with HTML and CSS](/dexign-html-css)
+* Guide 11: Continuous Deployment
+    * [Test your app with RSpec](testing-rspec) / [Ease up development with Phusion Passenger](/passenger) / [Simplifying your tests with Shoulda Matchers](testing-shoulda-matchers) / [CD with Travis-CI](/continuous-travis) / [CD with Codeship](/continuous) / [CD with Snap CI](/continuous-snap-ci)
+* Guide 12: [Build a voting app in Sinatra](/sinatra-app)
+* Guide 13: [Build a diary app in Ruby on Rails](diary-app)
+* Guide 14: [Add a back-end to your app (admin pages)](/backend-with-active-admin)
+* Guide 15: [Go through additional explanations for the App](https://github.com/lbain/railsgirls)

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ title: Guides
     <i>4</i>
     <h3>Put Your App Online</h3>
     <p>Instructions to get your app running on the internet. We have a lot of platforms to choose from:</p>
-    <p><a href="heroku">Heroku</a> | <a href="openshift">OpenShift</a> | <a href="engineyard">Engine Yard</a> | <a href="anynines">anynines</a> | <a href="passenger-development">prepare your app for deployment with Phusion Passenger</a>
+    <p><a href="heroku">Heroku</a> | <a href="openshift">OpenShift</a> | <a href="engineyard">Engine Yard</a> | <a href="anynines">anynines</a> | <a href="passenger">prepare your app for deployment with Phusion Passenger</a>
   </li>
 
   <li>
@@ -75,15 +75,15 @@ title: Guides
   <li>
     <a href="design">
       <i>6</i>
-      <h3>Apply a Modern Design with Bootstrap</h3>
-      <p>How to apply a CSS framework, such as Bootstrap.</p>
+      <h3>Add design using HTML &amp; CSS</h3>
+      <p>Let’s add some design to make it look like a professional website.</p>
     </a>
   </li>
 
   <li>
     <a href="thumbnails">
       <i>7</i>
-      <h3>Resize your Images Using Carrierwave</h3>
+      <h3>Create thumbnails with Carrierwave</h3>
       <p>Instructions on resizing your images using Carrierwave</p>
     </a>
   </li>
@@ -107,7 +107,7 @@ title: Guides
   <li>
     <a href="design-html-css">
       <i>10</i>
-      <h3>Design your App with HTML and CSS</h3>
+      <h3>Improve your design with HTML and CSS</h3>
       <p>How to improve HTML and CSS on your app</p>
     </a>
   </li>
@@ -115,7 +115,7 @@ title: Guides
   <li>
     <i>11</i>
     <h3>Continuous Deployment</h3>
-    <p><a href="testing-rspec">Test your application with RSpec</a> | <a href="passenger-development">Simplifying development with Phusion Passenger</a> | <a href="testing-shoulda-matchers">Simplifying tests with Shoulda Matchers</a>  <a href="continuous-travis">CD with Travis (and anynines)</a> | <a href="continuous">CD with Codeship (and Heroku)</a></p>
+    <p><a href="testing-rspec">Test your application with RSpec</a> | <a href="passenger">Ease up development with Phusion Passenger</a> | <a href="testing-shoulda-matchers">Simplifying tests with Shoulda Matchers</a>  <a href="continuous-travis">CD with Travis (and anynines)</a> | <a href="continuous">CD with Codeship (and Heroku)</a></p>
   </li>
 
 


### PR DESCRIPTION
**First change:**
Changed the order and sometimes names of the additional guides in the app tutorial to match the ones on the index page. Mostly to avoid confusion when participants want to go through all the guides at home. I myself felt sometimes like I was missing out on some guides because the names/order of them was different on the index page and at the bottom of the app tutorial.

**Second change:**
The links to the Passenger guides didn't work on the index page, so I changed that as well so now they work nicely. I hope this is okay @FloorD ?

**Third change:** 
There were two design guides on the index page. I changed their names to avoid confusion between the two. Hopefully this is okay with the guide creators @alexliao ?

**Fourth change.**
I also changed the name of the Carrierwave guide on the index page to the one used in the guide itself. Hope @mfilej doesn't mind?