### PR TITLE
Windows command window: Ctrl key shortcut options not neccessary experimental.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -140,7 +140,11 @@ For Windows 10 users:
 
 Open `Command Prompt with Ruby and Rails`.
 Right-click on the command prompt’s title bar, and choose "Properties".
-Navigate to the "experimental" tab, and check the "Enable new Ctrl key shortcuts" option (you may need to check the "Enable experimental console features" option first).
+Navigate to the "options" tab, and check "Enable Ctrl key shortcuts".
+(If you don't find it, but have an "experimental" tab,
+navigate there and check "Enable new Ctrl key shortcuts" option.
+In this case, you may need to check the "Enable experimental console
+features" option first.)
 
 For other Windows versions:
 


### PR DESCRIPTION
We saw in today's installation party that the instructions for the window terminal, where to activate the CTRL shortcuts, were a bit dated - at least on that particular participant's machine.

Here is the (German) screenshot. "STRG Tastenkombination aktivieren" is the one.

![screenshot-german](https://user-images.githubusercontent.com/1033352/47591389-b240f980-d96f-11e8-842b-709d162d03dd.png)
