### PR TITLE
add Docker development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.5
+
+LABEL maintainer="Rails Girls <contact@railsgirls.com>"
+
+WORKDIR /site
+
+RUN gem install jekyll
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install
+
+EXPOSE 4000
+
+CMD ["bundle", "exec", "jekyll", "server", "--watch", "-H", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ $ cd railsgirls.github.io
 $ bundle install
 ```
 
+## Quick start with Docker
+
+Alternatively, you can run the app using [Docker](https://docs.docker.com/install/):
+
+```
+$ docker build . -t railsgirls_dev
+$ docker run -p 80:4000 -v $(pwd):/site railsgirls_dev
+```
+
+Or, if you also have [Docker Compose](https://docs.docker.com/compose/install/), simply launch this command:
+
+```
+$ docker-compose up
+```
+
+The app will then be accessible on [127.0.0.1](http://127.0.0.1/)!
+
+Note: Thanks to the volume we created via the `-v` option or the `volumes` key in the `docker-compose.yml` file, the changes you make in the source code will directly be reflected in the container and you won't need to rebuild/restart every time to apply them.
+
 ### Pygments and Code Highlighting
 
 The guides use the [pygments](http://pygments.org/) library to do syntax highlighting. If you don't have it installed you won't be able to see the highlight sections like the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.3'
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/site
+    ports:
+      - "80:4000"


### PR DESCRIPTION
Hello :wave: 

This adds a `Dockerfile` and `docker-compose.yml` file in order to be able to use Docker as a development environment when contributing to the app.

The app can be launched with the whole ruby environment and Jekyll already installed via the `docker-compose up` command for instance, and then be accessible on `127.0.0.1` with every changes to the code being reflected thanks to Docker volumes.

(Note: This indeed requires to have Docker/Docker Compose installed, but I've also provided links in the readme :smile:)