### PR TITLE
Not to be processed to the '_site' folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,8 @@ exclude:
   - "Gemfile"
   - "Gemfile.lock"
   - "README.md"
+  - "node_modules/"
+  - "vendor/bundle/"
+  - "vendor/cache/"
+  - "vendor/gems/"
+  - "vendor/ruby/"


### PR DESCRIPTION
When executing `bundle install` with `--path vendor/bundle` option, `bundle exec jekyll server --watch` causes an error.

```
bundle exec jekyll server --watch
Configuration file: /Users/goh/src/github.com/railsgirls/railsgirls.github.io/_config.yml
            Source: /Users/goh/src/github.com/railsgirls/railsgirls.github.io
       Destination: /Users/goh/src/github.com/railsgirls/railsgirls.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
             Error: could not read file /Users/goh/src/github.com/railsgirls/railsgirls.github.io/vendor/bundle/ruby/2.5.0/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.5.0/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.5.0/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

The official trouble shooting page explains how to solve this.

- [Configuration problems](https://jekyllrb.com/docs/troubleshooting/#configuration-problems)