### PR TITLE
Fixed URL of git cheat sheet

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -143,5 +143,5 @@ git push origin master
 ### Learn more Git
 
  * Check out [trygit.org](http://try.github.io/)
- * Use a [Git Cheatsheet](https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
+ * Use a [Git Cheatsheet](https://github.github.com/training-kit/downloads/github-git-cheat-sheet/) ([PDF](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf))
  * Look up Git Commands at [git-scm.org](http://git-scm.com/)


### PR DESCRIPTION
Fixed URL of git cheat sheet

in http://guides.railsgirls.com/github