### PR TITLE
Remove bentobox example video link

### DIFF
--- a/_posts/2012-04-18-guide.markdown
+++ b/_posts/2012-04-18-guide.markdown
@@ -115,7 +115,6 @@ Two exercises: 1) Going through the 10 technical concepts with the physical Bent
 
 + [Bentobox slidedeck](http://speakerdeck.com/u/railsgirls/p/rails-girls-bentobox-exercise)
 + [Instruction video](http://vimeo.com/39049632)
-+ [Example video from Rails Girls ATL](http://vimeo.com/54912357)
 
 14:30 - 18:00 Workshop time.
 


### PR DESCRIPTION
"Example video from Rails Girls ATL" is not found.