### PR TITLE
App guide | Fix link to info page

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -421,7 +421,7 @@ add
 
 {% highlight html %}
 <li class="nav-item">
-  <a class="nav-link" href="/info">Info</a>
+  <a class="nav-link" href="/pages/info">Info</a>
 </li>
 {% endhighlight %}
 


### PR DESCRIPTION
I think the example link in the navigation to the `info` page is wrong.

We generate a `PagesController`. The generated route is `get 'pages/info'`. I can't see any mention that we change the route :see_no_evil: So I think the link should point to `/pages/info`.