### PR TITLE
Install Guide | Update Ruby version

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -71,7 +71,7 @@ source ~/.bash_profile
 You can find the newest version of Ruby with the command "rbenv install -l".
 
 {% highlight sh %}
-rbenv install 2.6.3
+rbenv install 2.6.4
 {% endhighlight %}
 
 If you got "OpenSSL::SSL::SSLError: ... : certificate verify failed" error, try it this way.
@@ -87,7 +87,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### *3a5.* Set default Ruby:
 
 {% highlight sh %}
-rbenv global 2.6.3
+rbenv global 2.6.4
 {% endhighlight %}
 
 #### *3a6.* Install rails:


### PR DESCRIPTION
Ruby 2.6.4 has been released on 28th of August 2019.

I don't know if there's a reason to keep it on `2.6.3`? `rbenv` certainly allows its installation. Not sure if it's installable on Windows etc. "already"?