### PR TITLE
Fix typo in title metadata field

### DIFF
--- a/_posts/2013-12-18-add-gravatar.markdown
+++ b/_posts/2013-12-18-add-gravatar.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Adding Graviatar to you app
+title: Adding Gravatar to you app
 permalink: gravatar
 ---
 


### PR DESCRIPTION
A friend just sent me the link and I was confused why it would show up like that in iMessage but not on the actual site, so I went to the source. 😅 

![image](https://user-images.githubusercontent.com/13483728/68958363-43c61800-07cc-11ea-9700-0c275000416b.png)
