### PR TITLE
Remove 'protect_from_forgery with: :exception'

### DIFF
--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -117,7 +117,7 @@ Finally, force the user to redirect to the login page if the user was not logged
   before_action :authenticate_user!
 {% endhighlight %}
 
-after `protect_from_forgery with: :exception`.
+after `class ApplicationController < ActionController::Base`.
 
 Open your browser and try logging in and out from.
 


### PR DESCRIPTION
 `protect_from_forgery with: :exception`  was removed from the `ApplicationController` in Rails 6, so I updated this part of the Devise tutorial.