### PR TITLE
guides/install: Recommend VSCode over Atom

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -120,9 +120,9 @@ If you need more information than the following to install yarn, please check [y
 
 ### _5._ Install a text editor to edit code files
 
-For the workshop we recommend the text editor Atom.
+For the workshop we recommend the text editor Visual Studio Code.
 
-* [Download Atom and install it](https://atom.io/)
+* [Download VS Code and install it](https://code.visualstudio.com).
 
 If you are using Mac OS X 10.7 or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2). Just to make sure that you're not mixing up using your terminal or text-editor: change the theme of your Sublime text-editor, choosing one of the following: "iPlastic", "Slush &amp; Poppies", or "Zenburnesque".
 


### PR DESCRIPTION
Hello from a former student who took one of your courses many years ago!

I noticed that the main install guide still recommends Atom as a text editor. It is a perfectly good text editor, but it is being sunset and no longer maintained by GitHub as of December 15th, 2022: https://github.blog/2022-06-08-sunsetting-atom/.

In [StackOverflow's 2022 developer survey](https://survey.stackoverflow.co/2022/#section-most-popular-technologies-integrated-development-environment), Visual Studio Code was the preferred code editor for 74.48% of respondents vs. Atom's 9.35%.

Thanks!