### PR TITLE
guides/install: Update Homebrew install command

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -42,10 +42,10 @@ If your version number starts with 10.9, 10.10, 10.11 or higher, follow these st
 xcode-select --install
 {% endhighlight %}
 
-#### *3a2.* Install [Homebrew](http://brew.sh/):
+#### *3a2.* Install [Homebrew](https://brew.sh/):
 
 {% highlight sh %}
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 {% endhighlight %}
 
 #### *3a3.* Install [rbenv](https://github.com/rbenv/rbenv):


### PR DESCRIPTION
- The old command shows the following error message. Let's save newcomers the extra copy/paste.

```
❯ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
Error: The Ruby Homebrew installer is now disabled and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```
