### PR TITLE
Update the install instructions to Ruby 3.1

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -91,7 +91,7 @@ source ~/.zshrc
 You can find the newest version of Ruby with the command "rbenv install -l".
 
 {% highlight sh %}
-rbenv install 3.0.4
+rbenv install 3.1.3
 {% endhighlight %}
 
 If you got "OpenSSL::SSL::SSLError: ... : certificate verify failed" error, try it this way.
@@ -107,22 +107,22 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### _3a5._ Set default Ruby:
 
 {% highlight sh %}
-rbenv global 3.0.4
+rbenv global 3.1.3
 {% endhighlight %}
 
 {% highlight sh %}
-rbenv local 3.0.4
+rbenv local 3.1.3
 {% endhighlight %}
 
 {% highlight sh %}
-rbenv shell 3.0.4
+rbenv shell 3.1.3
 {% endhighlight %}
 
-Check that your `ruby` version matches what you installed:
+Check that your `ruby` version matches what you installed. It will look something like the output below, make sure the `ruby 3.1.3` part matches.
 
 {% highlight sh %}
 ruby --version
-ruby 3.0.4p208 (2022-04-12 revision 3fa771dded) [arm64-darwin20]
+ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin22]
 {% endhighlight %}
 
 #### _3a6._ Install rails:
@@ -205,7 +205,7 @@ _During these steps we'll ask you to open and close the Windows Command Prompt e
 ### _1._ Install Ruby
 
 - Download the [RubyInstaller](https://rubyinstaller.org/downloads/) for Windows.
-  - [Direct link to Ruby 3.0.4 installer with Devkit](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.4-1/rubyinstaller-devkit-3.0.4-1-x86.exe) for 32-bit architecture.
+  - [Direct link to Ruby 3.1.3 installer with Devkit](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.3-1/rubyinstaller-3.1.3-1-x86.exe) for 32-bit architecture.
 - Run the installer. Click through the installer using all the default options.
   - When prompted with the "MSYS2" installer, enter `1` and press Enter.
   - When prompted with the same "MSYS2" installer again, only press Enter.


### PR DESCRIPTION
Update the instructions to install Ruby 3.1.3. Ruby 3.2 is out, but it may still have some issues with installing some gems, Ruby 3.1 is more stable.