### PR TITLE
Suggest Visual Studio Code as an Atom replacement

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -19,7 +19,7 @@ permalink: app
 
 ### Text Editor
 
-* [Atom](https://atom.io/), [Sublime Text](http://www.sublimetext.com),  Vim and Emacs are examples of text editors your can use for writing code and editing files.
+* [Visual Studio Code](https://code.visualstudio.com/), [Sublime Text](http://www.sublimetext.com), Vim and Emacs are examples of text editors your can use for writing code and editing files.
 
 <h3><i class="icon-prompt">&nbsp;</i></h3>
 

--- a/_posts/2014-10-05-diary-app.markdown
+++ b/_posts/2014-10-05-diary-app.markdown
@@ -24,7 +24,7 @@ __COACH__: For the rationale behind this slightly different beginners tutorial, 
 
 ### Text Editor
 
-* [Atom](https://atom.io/), [Sublime Text](http://www.sublimetext.com),  Vim and Emacs are examples of text editors your can use for writing code and editing files.
+* [Visual Studio Code](https://code.visualstudio.com/), [Sublime Text](http://www.sublimetext.com), Vim and Emacs are examples of text editors your can use for writing code and editing files.
 
 <h3><i class="icon-prompt">&nbsp;</i></h3>
 


### PR DESCRIPTION
The Atom editor has been sunset and clicking the link to the homepage ends up on the GitHub blog post about sunsetting the editor. This is confusing to readers and we should suggest another editor instead. VS Code is suggested in other parts of the guide already, let's stick with that.