### PR TITLE
Add a tools guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,7 @@
 permalink: pretty
 markdown: kramdown
+include:
+  - _pages
 exclude:
   - ".rvmrc"
   - ".rbenv-version"

--- a/_includes/other-guides.md
+++ b/_includes/other-guides.md
@@ -3,6 +3,7 @@
 ## Other Guides
 
 * [Handy cheatsheet for Ruby, Rails, console etc.](http://www.pragtob.info/rails-beginner-cheatsheet/)
+* Guide 0: [Get to know the tools](/tools) {% if include.page == 'tools' %}(Current page!){% endif %}
 * Guide 1: [Guide to install Rails](/install) {% if include.page == 'install' %}(Current page!){% endif %}
 * Guide 2: [Build Your First App](/app) {% if include.page == 'app' %}(Current page!){% endif %}
 * Guide 3: [Push Your App to GitHub](/github) {% if include.page == 'github' %}(Current page!){% endif %}

--- a/_pages/tools.markdown
+++ b/_pages/tools.markdown
@@ -1,0 +1,81 @@
+---
+layout: default
+title: Get to know the tools
+permalink: tools
+---
+
+# Get to know the tools
+
+Start by getting familiar with the tools you'll be using in this workshop. Please install the tools you do not have yet installed and move on to the next guide.
+
+## <i class="icon-text-editor"></i> Text Editor {#text-editor}
+
+To create your app you'll need to write code. This can be done with a Text Editor made for writing code. Listed below are examples of text editors your can use for writing code and editing files. We recommend <strong>Visual Studio Code</strong> as it's a very complete package that works out of the box.
+
+Choose an editor, go to the website linked below and install it following the instructions on the website.
+
+* [Visual Studio Code](https://code.visualstudio.com) (Recommended)
+* [Sublime Text](http://www.sublimetext.com)
+
+## <i class="icon-prompt"></i> Terminal {#terminal}
+
+The Terminal is a tool to run commands on your system for applications that do not have a Graphical User Interface (GUI), like many of the tools we'll be using today.
+The Terminal is also known as PowerShell or Command Prompt on Microsoft Windows, we'll be referring to this as the Terminal throughout these guides.
+
+In the Terminal app you'll do things like:
+
+* Install the required tools (Ruby, databases, and others);
+* Start your Rails app;
+* Run database migrations;
+* etc.
+
+Open the Terminal like so for your Operating System:
+
+### macOS/OSX
+
+- Open Spotlight:
+    - Click the Magnifing glass icon in the menu bar at the uppermost top right of your screen, or;
+    - Press <kbd>command + space bar</kbd> (The command key can be recognized by the <kbd>⌘</kbd> symbol).
+- Type in "Terminal" or "iTerm".
+- Press <kbd>Enter</kbd> to open the Terminal app.
+
+### Microsoft Windows
+
+- Open "Start" by:
+    - Clicking on the Windows icon in the bottom left, or;
+    - press the <kbd>Window flag key</kbd>.
+- Type in "PowerShell" or "Command Prompt", whichever is available.
+- Press <kbd>Enter</kbd> to open the Terminal app.
+
+## Code examples
+
+Throughout this guide you will see bits of text formatted like the block below. The icon next to the text will let you know which tool to use.
+
+The text in the block below is a terminal command. This can be recognized by the Terminal icon on its left side. It needs to be run in the Terminal. Copy it from the page, paste it in the Terminal app and press the <kbd>Enter</kbd> key.
+
+{% highlight sh %}
+Some terminal command example
+{% endhighlight %}
+
+The text in the block below is source code. This can be recognized by the Text Editor icon on its left side. It needs to be inserted into one of your project files.
+
+{% highlight erb %}
+Some source code example
+{% endhighlight %}
+
+
+## <i class="icon-browser"></i> Web browser {#web-browser}
+
+You should already have a webbrowser installed. It's what you use to view this page on your laptop. You should not have to install any of these, one should already be installed, but just so you know what they're named.
+
+- Edge (this is preinstalled on Microsoft Windows laptops)
+- Safari (this is preinstalled on macOS laptops)
+- Alternatives you may be using instead:
+    - [Google Chrome](https://www.google.com/chrome/index.html)
+    - [Firefox](https://www.mozilla.org/firefox/)
+
+---
+
+You should now have a Text Editor installed, you know where to find the Terminal and you have your browser open. On to the next guide!
+
+{% include other-guides.md page="tools" %}

--- a/_pages/tools.markdown
+++ b/_pages/tools.markdown
@@ -47,6 +47,8 @@ Open the Terminal like so for your Operating System:
 - Type in "PowerShell" or "Command Prompt", whichever is available.
 - Press <kbd>Enter</kbd> to open the Terminal app.
 
+If the options above are not available, press the <kbd>Window flag key + R</kbd>, type in `cmd` and press <kbd>Enter</kbd> to open the Command Prompt Terminal app.
+
 ## Code examples
 
 Throughout this guide you will see bits of text formatted like the block below. The icon next to the text will let you know which tool to use.

--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -10,43 +10,6 @@ permalink: app
 
 **Make sure you have Rails installed.** [**Follow the installation guide**](/install) to get set up.
 
-
-## Get to know the tools
-
-<div class="indent" markdown="1">
-
-<h3><i class="icon-text-editor">&nbsp;</i></h3>
-
-### Text Editor
-
-* [Visual Studio Code](https://code.visualstudio.com/), [Sublime Text](http://www.sublimetext.com), Vim and Emacs are examples of text editors your can use for writing code and editing files.
-
-<h3><i class="icon-prompt">&nbsp;</i></h3>
-
-### Terminal (known as Command Prompt on Windows)
-
-* Where you start the rails server and run commands.
-* This is a program on your computer that you can get to through your Spotlight search on Mac (search for "Terminal"), or by searching for the "Command Prompt" in your programs on Windows.
-
-<h3><i class="icon-browser">&nbsp;</i></h3>
-
-### Web browser
-
-* (Firefox, Safari, Chrome) for viewing your application.
-
-</div>
-
-Throughout this guide you will see bits of code formatted like so:
-
-{% highlight sh %}
-some code
-{% endhighlight %}
-
-<div>
-<p>This means that the highlighted text is code and it probably needs to be either executed or inserted into one of your project files. The icon next to the highlighted text will let you know which tool to use.</p>
-<p>For example, if you see a terminal icon next to the highlight, like in the example above, you will need to copy the code and paste it into your Terminal (Mac) / Command Prompt (Windows).</p>
-</div>
-
 Need some reminders along the way? Check out this [handy cheatsheet for Ruby, Rails, console etc.](http://www.pragtob.info/rails-beginner-cheatsheet/)
 
 ### Important

--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -20,14 +20,7 @@ It is important that you select the instructions specific to your operating syst
 
 We're going to create a new Rails app called *railsgirls*.
 
-First, let's open a terminal:
-
-* macOS: Open Spotlight, type *Terminal* and click the *Terminal* application.
-* Windows: Click Start and look for *Command Prompt*, then click *Command Prompt with Ruby and Rails*.
-* Linux (Ubuntu/Fedora): Search for *Terminal* on the dash and click *Terminal*.
-* Cloud service (e.g. Codenvy): Log in to your account, start your project and switch to its IDE (see [installation guide](/install#using-a-cloud-service) for details). The terminal is usually at the bottom of your browser window.
-
-Next, type these commands in the terminal:
+First, open the Terminal app and type in these commands:
 
 <div class="os-specific">
   <div class="nix">

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -158,14 +158,6 @@ brew install yarn
 
 If you need more information than the following to install yarn, please check [yarn's installation docs](https://yarnpkg.com/lang/en/docs/install/).
 
-### _5._ Install a text editor to edit code files
-
-For the workshop we recommend the text editor Visual Studio Code.
-
-- [Download VS Code and install it](https://code.visualstudio.com).
-
-If you are using Mac OS X 10.7 or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2). Just to make sure that you're not mixing up using your terminal or text-editor: change the theme of your Sublime text-editor, choosing one of the following: "iPlastic", "Slush &amp; Poppies", or "Zenburnesque".
-
 ### _5._ Check the environment
 
 Check that everything is working by running the application generator command.
@@ -282,15 +274,7 @@ rails --version
 
 _If you run into any problems during this step, check the [Possible errors](#possible-errors-during-installation) section for possible solutions._
 
-### _6._ Install a text editor to edit code files
-
-For the workshop we recommend the text editor Visual Studio Code.
-
-- Visit the [VS Code download page](https://code.visualstudio.com) and follow the instructions.
-
-If you are using Windows Vista or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2). Just to make sure that you're not mixing up using your command prompt or text-editor: change the theme of your Sublime text-editor, choosing one of the following: "iPlastic", "Slush &amp; Poppies", or "Zenburnesque".
-
-### _7._ Check the environment
+### _6._ Check the environment
 
 Check that everything is working by running the application generator command.
 
@@ -372,13 +356,7 @@ Make sure that all works well by running the application generator command.
 rails new myapp
 {% endhighlight %}
 
-### _4._ Install a text editor to edit code files
-
-For the workshop we recommend the text editor Sublime Text.
-
-- [Download Sublime Text and install it](http://www.sublimetext.com/2). Just to make sure that you're not mixing up using your terminal or text-editor: change the theme of your Sublime text-editor, choosing one of the following: "iPlastic", "Slush &amp; Poppies", or "Zenburnesque".
-
-### _5._ Check the environment
+### _4._ Check the environment
 
 Check that everything is working by running the application generator command.
 

--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -12,29 +12,6 @@ permalink: simpleapp
 
 **Make sure you have Rails installed.** [**Follow the installation guide**](/install) to get set up.
 
-
-## Get to know the tools
-
-<div class="indent" markdown="1">
-
-<h3><i class="icon-text-editor">&nbsp;</i></h3>
-
-<h3>Text Editor</h3>
-
-<p><a href="http://www.sublimetext.com">Sublime Text</a>, <a href="http://www.activestate.com/komodo-edit">Komodo Edit</a>, Vim, Emacs, and Gedit are examples of text editors your can use for writing code and editing files.</p>
-
-<h3><i class="icon-prompt">&nbsp;</i></h3>
-
-<h3>Terminal (known as Command Prompt on Windows)</h3>
-Where you start the rails server and run commands.
-
-<h3><i class="icon-browser">&nbsp;</i></h3>
-
-<h3>Web browser</h3>
-(Firefox, Safari, Chrome) for viewing your application.
-
-</div>
-
 ### Important
 
 It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands.

--- a/_posts/2014-05-09-test-driven-development.markdown
+++ b/_posts/2014-05-09-test-driven-development.markdown
@@ -123,9 +123,7 @@ end
 
 **Run your tests**
 
-If you use *Sublime Text* on Linux, OSX Mavericks (or later) or Windows, you
-can run the tests by pressing <kbd>Ctrl</kbd>+<kbd>B</kbd>. Otherwise you can type the following into
-your terminal:
+Run the command following into the terminal:
 
 {% highlight sh %}
 ruby roman.rb

--- a/_posts/2014-05-10-sinatra.markdown
+++ b/_posts/2014-05-10-sinatra.markdown
@@ -64,7 +64,7 @@ gem install sinatra-contrib
 {% endhighlight %}
 
 ## *1.* "Hello World"
-Create a file called `app.rb` and paste the following into Sublime Text:
+Create a file called `app.rb` and paste the following into your Text Editor:
 
 {% highlight ruby %}
 require "sinatra"

--- a/_posts/2014-05-29-touristic-autism_basic-app.markdown
+++ b/_posts/2014-05-29-touristic-autism_basic-app.markdown
@@ -10,28 +10,6 @@ permalink: touristic-autism_basic-app
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
 The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](http://www.railstutorial.org/book), the [basic RailsGirls app](http://guides.railsgirls.com/app/) and the tutorials for [creating thumbnails](http://guides.railsgirls.com/thumbnails), [authenticating users](http://guides.railsgirls.com/devise/), [adding design](http://guides.railsgirls.com/design), [deploying to OpenShift](http://guides.railsgirls.com/openshift/) and [adding comments](http://guides.railsgirls.com/commenting).
 
-
-
-## Get to know the tools
-
-<div class="indent" markdown="1">
-
-<h3><i class="icon-text-editor">&nbsp;</i></h3>
-
-<h3>Text Editor</h3>
-
-<p><a href="http://www.sublimetext.com">Sublime Text</a>, <a href="http://www.activestate.com/komodo-edit">Komodo Edit</a>, Vim, Emacs, and Gedit are examples of text editors your can use for writing code and editing files.</p>
-
-<h3><i class="icon-prompt">&nbsp;</i></h3>
-
-<h3>Terminal (known as Command Prompt on Windows)</h3>
-Where you start the rails server and run commands.
-
-<h3><i class="icon-browser">&nbsp;</i></h3>
-
-<h3>Web browser</h3>
-(Firefox, Safari, Chrome) for viewing your application.
-
 <h3>GitHub</h3>
 [Slides - by Kevin Lyda @]()
 

--- a/_posts/2014-10-05-diary-app.markdown
+++ b/_posts/2014-10-05-diary-app.markdown
@@ -15,33 +15,6 @@ __COACH__: For the rationale behind this slightly different beginners tutorial, 
 
 **Make sure you have Rails installed.** [**Follow the installation guide**](/install) to get set up.
 
-
-## Get to know the tools
-
-<div class="indent" markdown="1">
-
-<h3><i class="icon-text-editor">&nbsp;</i></h3>
-
-### Text Editor
-
-* [Visual Studio Code](https://code.visualstudio.com/), [Sublime Text](http://www.sublimetext.com), Vim and Emacs are examples of text editors your can use for writing code and editing files.
-
-<h3><i class="icon-prompt">&nbsp;</i></h3>
-
-### Terminal (known as Command Prompt on Windows)
-
-* Where you start the rails server and run commands.
-
-<h3><i class="icon-browser">&nbsp;</i></h3>
-
-### Web browser
-
-* (Firefox, Safari, Chrome) for viewing your application.
-
-__COACH__: Assist with the installation; make sure the text editor is set up properly (e.g., check whether the encoding is UTF-8).
-
-</div>
-
 ### Important
 
 It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands. In case you're using a cloud service (e.g. nitrous), you need to run the Linux commands even if you are on a Windows computer.

--- a/index.html
+++ b/index.html
@@ -33,6 +33,14 @@ title: Guides
   </li>
 
   <li>
+    <a href="/tools">
+      <i>0</i>
+      <h3>Get to know the tools</h3>
+      <p>Learn which tools we'll be using during the workshop and where to find them.</p>
+    </a>
+  </li>
+
+  <li>
     <a href="install">
       <i>1</i>
       <h3>Guide to Install Rails</h3>


### PR DESCRIPTION
Add a new tools guide based on parts of guides that were scattered around other guides. Now these instructions are consistent.

Also make it the very first guide. The install guide started with asking people to run commands in the Terminal, without having had an introduction to what the Terminal app is.

I numbered it guide 0, so I didn't have to renumber all the guides right now. That can be done later.

I added a new `_pages` directory so that this file doesn't need a date attached to it. Let's move the other guides over at some point. I'll be updating more guides in the coming weeks to do so.