### PR TITLE
Remove mentions of Nitrous.io

### DIFF
--- a/_posts/2014-10-05-diary-app.markdown
+++ b/_posts/2014-10-05-diary-app.markdown
@@ -44,7 +44,7 @@ __COACH__: Assist with the installation; make sure the text editor is set up pro
 
 ### Important
 
-It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands. In case you're using a cloud service (e.g. nitrous), you need to run the Linux commands even if you are on a Windows computer.
+It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands. In case you're using a cloud service, you need to run the Linux commands even if you are on a Windows computer.
 
 ## Pure HTML
 
@@ -119,8 +119,6 @@ __COACH__: Explain how the Web works and talk a bit about HTML elements and attr
 [Here](https://github.com/krzysztofbialek/Rails-Girls-Warsaw-App)'s a link to repo with styled basic app you can use.
 
 ## Moving to Rails
-
-__COACH__: If your students are on Windows, consider using Nitrous.IO as the basis for the following parts.
 
 ### New Rails application
 


### PR DESCRIPTION
The service has shut down.

Related #244