### PR TITLE
Update contributing guide to use pages dir

### DIFF
--- a/_pages/contributing.markdown
+++ b/_pages/contributing.markdown
@@ -13,7 +13,7 @@ The guides site uses [jekyll](https://github.com/mojombo/jekyll) to power the si
 
 ## If you want to add a new guide:
 
-- Create a file named `YYYY-MM-DD-guide_name.markdown` inside the `_posts` directory of your fork.
+- Create a file named `guide_name.markdown` inside the `_pages` directory of your fork.
 - In this file, you'll need to add some YAML front matter at the top of the file so it looks like the following example, taken from this guide that you are currently viewing:
 
     <pre>


### PR DESCRIPTION
Let's move all the content to the `_pages` dir, and not use the `_posts`. This website is not a blog. It also doesn't need prefixes for dates, as most are many years old, but the pages themselves are much more recently updated.