### PR TITLE
Guide links

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@ title: Guides
     <a href="https://railsgirlslima.github.io/">Guides in Spanish</a><br>
     <a href="https://railsgirls.tw/">Guides in Traditional Chinese</a><br>
     <a href="https://railsgirlshh.github.io/">Guides in German</a><br>
-    <a href="http://guides.railsgirls.co.il/">Guides in Hebrew</a><br>
     <a href="http://railsgirls.rug.lviv.ua/">Guides in Ukrainian</a><br>
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@ title: Guides
       <i>2</i>
       <h3>Build Your First App</h3>
       <p>Guide to building your first app with Ruby on Rails.</p>
-      <p>Guides can be found in <a href="http://railspremierspas.humancoders.com/">French</a>, <a href="https://rgcn.github.io">Chinese</a>, <a href="https://railsgirlshh.github.io/">German</a>, and  <a href="http://guides.railsgirls.co.il/">Hebrew</a> too.</p>
     </a>
   </li>
 


### PR DESCRIPTION
## Remove duplicates for guides in other languages

A more complete list of the guides in other languages can be found at the top of the page.

## Remove Hebrew guide link

The link does not resolve anymore.
