### PR TITLE
Update Git and GitHub guide

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -1,149 +1,148 @@
 ---
 layout: default
-
-title: How to Push to GitHub
-
+title: Push your app to GitHub
 permalink: github
 ---
 
-# Push Your App to GitHub
+# Push your app to GitHub
 
 *Created by Alyson La, [@realalysonla](https://www.twitter.com/realalysonla)*
 
-## Things you need before you get started
+Git is a tool with which it's possible to save your app's source code, view changes over time, share code online and collaborate with others.
 
-### Git & GitHub
+**COACH:** Talk a little about Git, version control, collaborating with others using Git, GitHub, deployment techniques using Git and Open Source.
 
-* Check if Git is installed
-	* In the terminal type `git --version` (1.8 or higher preferred)
+## Installing Git
 
-* If not, download Git [here](http://git-scm.com/downloads).
-	Then, setup your local Git profile - In the terminal:
-	* Type `git config --global user.name "your-name"`
-	* Type `git config --global user.email "your-email"`
-
-	* _To check if Git is already config-ed you can type_ `git config --list`
-
-* Create a free [GitHub](https://github.com) account or login if you already have one
-
-**COACH:** Talk a little about git, version control, and open source
-
-## Push your app to GitHub using the command line
-
-On your GitHub profile click "new repo" ![screen shot 2013-06-01 at 12 38 50 pm](https://f.cloud.github.com/assets/2623954/595307/eb70c6cc-caf2-11e2-9d2d-60deb31ac049.png) give it a name (example: rails-girls), brief description, choose the "public" repo option, and click "create repository".
-
-In the command line--make sure you `cd` into your railgirls folder--and type:
+Before working with Git, we first need to check if Git is already installed. In the terminal type the following command:
 
 {% highlight sh %}
-git init
+git --version
 {% endhighlight %}
 
-This initializes a git repository in your project
-
-*Note:* If you've already done the [Heroku guide](/heroku), then you've already initialized a git repository & you can move on to the next steps.
-
-Next check if a file called `README.rdoc` exists in your railsgirls directory:
+The output should mention Git version 1.8 or higher. If it is not installed (indicated by a "command not found" or similar error), or the version is lower than 1.8, please install or upgrade Git.
 
 <div class="os-specific">
   <div class="nix">
+<p>Run this command in the Terminal to install or upgrade Git on macOS.</p>
 {% highlight sh %}
-ls README.rdoc
+brew install git
 {% endhighlight %}
   </div>
   <div class="win">
-{% highlight sh %}
-dir README.rdoc
-{% endhighlight %}
+<p>Please install Git by going to the <a href="https://git-scm.com/download/win">Git website</a>, download the Git installer for Windows and running the downloaded installer.</p>
   </div>
 </div>
 
-If the file doesn't exist, create it by typing:
+After installing or upgrading, run the `git --version` command again to make sure you are using a more recent version.
 
-<div class="os-specific">
-  <div class="nix">
+## Configuring Git
+
+Once we're sure Git is installed, we can set up our local profile in Git. This profile will be used to describe who made the changes to files we'll store in Git. You can see who made which change and when.
+
+Change "your name" and "your email" with your name and your email address. You can also use a nickname or an alias if you want to use your real name and email address. Be aware: the name and email address you configure here will be visible to others!
+
 {% highlight sh %}
-touch README.rdoc
+git config --global user.name "your-name"
+git config --global user.email "your-email"
 {% endhighlight %}
-  </div>
-  <div class="win">
+
+To check if a profile is already set up in Git, you can run this command, and look for the `user.name` and `user.email` values in the output:
+
 {% highlight sh %}
-type nul > README.rdoc
+git config --list
 {% endhighlight %}
-  </div>
-</div>
 
-**COACH:** Talk a little about README.rdoc
+## Saving work in Git
 
-Then type:
+Open the Terminal app, navigate to your _railsgirls_ app directory and run the following command. This will list out all the changed files in your app directory, which should be all the files for your app.
 
 {% highlight sh %}
 git status
 {% endhighlight %}
 
-This will list out all the files in your working directory.
-
-**COACH:** Talk about some of your favorite git commands
-
-Then type:
+We want to save all these files in Git so they can be pushed to the GitHub repository you just created. By running the following command you will add all those files staging area in Git, ready to be saved (committed).
 
 {% highlight sh %}
 git add .
 {% endhighlight %}
 
-This adds in all of your files & changes so far to a staging area.
-
-Then type:
+The `git commit` command shown below will save the staged files in Git, along with the message "First commit".
 
 {% highlight sh %}
-git commit -m "first commit"
+git commit -m "First commit"
 {% endhighlight %}
 
-This commits all of your files, adding the message "first commit"
+(The `-m` in the above command stands for "message".)
 
-Next type:
+## Create a GitHub account
 
-{% highlight sh %}
-git remote add origin https://github.com/username/rails-girls.git
-{% endhighlight %}
+GitHub is a free online code sharing platform. It is a _hub_ for source code saved in _Git_. We will use this to save and share our apps source code.
 
-_Your GitHub Repository page will list the repository URL, so feel free to copy and paste from there, rather than typing it in manually. You can copy and paste the link from your GitHub repository page by clicking the clipboard icon next to the URL._
+Visit the [GitHub website](https://github.com) and create an account or login if you already have one.
 
-This creates a remote, or _connection_, named "origin" pointing at the GitHub repository you just created.
+## Push your app to GitHub using the command line
 
-Then type:
+You can now push (Git terminology for _upload_) your saved work to GitHub and share it with others.
+
+Once signed in to GitHub, click on the plus icon (`+`) in the top right corner of the navigation bar. In the dropdown, choose "New repository".
+Having trouble finding the right link? Visit this [new repository page](https://github.com/new) directly.
+
+On the "Create a new repository" page, enter a repository name (like "railsgirls"), choose "public" for the repository's visibility and click the "Create repository" button. Leave the rest of the form untouched.
+
+The next page will list the repository URL we will need to tell Git where to push your app's source code to. In the instructions on the page, find the line that starts with `git remote add origin`. Copy the entire line and paste it into the Terminal app. Then press enter.
+
+This step creates a Git _remote_, a _connection_, named "origin" pointing to the GitHub repository you just created in the local repository.
+
+Now we want to _push_ to local changes in the Git repository to repository on GitHub with the following command.
 
 {% highlight sh %}
 git push -u origin master
 {% endhighlight %}
 
-This sends your commits in your "master" branch to GitHub
+Congratulations your app is on GitHub! Refresh the page in the Browser and you should see a bunch of files there now.
 
-Congratulations your app is on GitHub! Go check it out by going to the same url you used above: https://github.com/username/rails-girls (without the .git part)
+## Saving more changes in Git
 
-If you want to continue making changes and pushing them to GitHub you'll just need to use the following three commands:
+If you want to continue making changes and pushing them to GitHub you'll just need to use the following three commands.
+
+Add changes you want to save in Git to the _staging area_:
 
 {% highlight sh %}
 git add .
-git commit -m "type your commit message here"
-git push origin master
 {% endhighlight %}
+
+Save the changes with a commit message:
+
+{% highlight sh %}
+git commit -m "Type your commit message here"
+{% endhighlight %}
+
+Use a descriptive message so you can find back what you changed in which commit and why.
 
 **COACH:** Talk about what makes a good commit message (active, descriptive and short).
 
+And push the changes to GitHub:
+
+{% highlight sh %}
+git push origin master
+{% endhighlight %}
+
 ## What's next?
 
-### Be a Part of the Open Source Community
+### Learn more about Git
 
- * Follow your fellow Rails Girls & coaches on GitHub
- * Star or watch their projects
- * [Fork](https://help.github.com/articles/fork-a-repo) a repo, then clone and push changes to your fork. Share the changes with the originator by sending them a [pull request](https://help.github.com/articles/using-pull-requests)!
- * Create an issue on a project when you find a bug
- * Explore other open source projects - search by programming language or key word
+* Use a [Git Cheatsheet](https://training.github.com/downloads/github-git-cheat-sheet/) for frequently used commands ([also available as a PDF](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf)).
+* Look up more Git commands in [the Git documentation](https://git-scm.com/docs).
+* Try out a Graphical User Interface (GUI) if you prefer a more visual experience for using Git. Try out an app like [GitHub Desktop](https://desktop.github.com/).
+* In the future, as you'll work with more people on a project, you'll start working with branches and pull requests more often.
 
-### Learn more Git
+### Be a part of the Open Source community
 
- * Check out [trygit.org](http://try.github.io/)
- * Use a [Git Cheatsheet](https://github.github.com/training-kit/downloads/github-git-cheat-sheet/) ([PDF](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf))
- * Look up Git Commands at [git-scm.org](http://git-scm.com/)
+* Follow your fellow Rails Girls & coaches on GitHub and see what they're working on.
+* Star or watch their projects.
+* [Fork a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) (a "repo"), then clone and push changes to your fork. Share the changes with the originator by sending them a [pull request](https://help.github.com/articles/using-pull-requests)!
+* Create an issue on a project when you find a bug.
+* Explore other Open Source projects - search by programming language or keyword.
 
 {% include other-guides.md page="github" %}


### PR DESCRIPTION
Change around the order to focus on Git first and then to GitHub when all the Git commands are discussed.

The `rails new` command also initializes a repository already, so the guides doesn't need a step for this.

There's one problem with this guide still: authentication. GitHub no longer supports password authentication and this guide does not address how to authenticate with GitHub right now. This will addressed later.

Created an issue for it in #505 