### PR TITLE
Add Mac option in OS switcher for instructions

### DIFF
--- a/_pages/tools.markdown
+++ b/_pages/tools.markdown
@@ -31,21 +31,39 @@ In the Terminal app you'll do things like:
 
 Open the Terminal like so for your Operating System:
 
-### macOS/OSX
+<div class="os-specific">
+  <div class="mac">
+    <ul>
+      <li>
+        Open Spotlight:
+        <ul>
+          <li>Click the Magnifing glass icon in the menu bar at the uppermost top right of your screen, or;</li>
+          <li>Press <kbd>command + space bar</kbd> (The command key can be recognized by the <kbd>⌘</kbd> symbol).</li>
+        </ul>
+      </li>
+      <li>Type in "Terminal" or "iTerm".</li>
+      <li>Press <kbd>Enter</kbd> to open the Terminal app.</li>
+    </ul>
+  </div>
 
-- Open Spotlight:
-    - Click the Magnifing glass icon in the menu bar at the uppermost top right of your screen, or;
-    - Press <kbd>command + space bar</kbd> (The command key can be recognized by the <kbd>⌘</kbd> symbol).
-- Type in "Terminal" or "iTerm".
-- Press <kbd>Enter</kbd> to open the Terminal app.
+  <div class="win">
+    <ul>
+      <li>
+        Open the "Start" menu by:
+        <ul>
+          <li>Clicking on the Windows icon in the bottom left, or;</li>
+          <li>press the <kbd>Window flag</kbd> key on the keyboard.</li>
+        </ul>
+      </li>
+      <li>Type in "PowerShell" or "Command Prompt", whichever is available.</li>
+      <li>Press <kbd>Enter</kbd> to open the Terminal app.</li>
+    </ul>
+  </div>
 
-### Microsoft Windows
-
-- Open "Start" by:
-    - Clicking on the Windows icon in the bottom left, or;
-    - press the <kbd>Window flag key</kbd>.
-- Type in "PowerShell" or "Command Prompt", whichever is available.
-- Press <kbd>Enter</kbd> to open the Terminal app.
+  <div class="nix">
+    <p>Please consult your Linux distribution's documentation about how to open apps, and open the <em>Terminal</em> app.</p>
+  </div>
+</div>
 
 If the options above are not available, press the <kbd>Window flag key + R</kbd>, type in `cmd` and press <kbd>Enter</kbd> to open the Command Prompt Terminal app.
 

--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -23,7 +23,7 @@ We're going to create a new Rails app called *railsgirls*.
 First, open the Terminal app and type in these commands:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 mkdir projects
 {% endhighlight %}
@@ -107,7 +107,7 @@ You should see a page with the Rails logo, which means that your Rails app is up
 Notice in the Terminal window the command prompt is not visible because you are now in the Rails server. The command prompt will look something like this, but it may be different on your laptop:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 $
 {% endhighlight %}

--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -23,11 +23,14 @@ git --version
 The output should mention Git version 1.8 or higher. If it is not installed (indicated by a "command not found" or similar error), or the version is lower than 1.8, please install or upgrade Git.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac">
 <p>Run this command in the Terminal to install or upgrade Git on macOS.</p>
 {% highlight sh %}
 brew install git
 {% endhighlight %}
+  </div>
+  <div class="nix">
+<p>Follow the <a href="https://git-scm.com/download/linux">instructions for your Operating System</a> in the Git documentation.</p>
   </div>
   <div class="win">
 <p>Please install Git by going to the <a href="https://git-scm.com/download/win">Git website</a>, download the Git installer for Windows and running the downloaded installer.</p>

--- a/_posts/2013-11-12-openshift.markdown
+++ b/_posts/2013-11-12-openshift.markdown
@@ -79,7 +79,7 @@ __COACH__: Explain the Git commands used and .gitignore.
 We need the `.openshift` directory and `config/database.yml` file from the sample application for our Rails app to run on OpenShift. Copy these from the `openshiftapp` directory to the `railsgirls` directory. You can use Windows Explorer or another graphical file system tool to do this if you like, or alternatively run the following commands from the `railsgirls` directory in your terminal:
 
 <div class="os-specific">
-   <div class="nix">
+   <div class="mac nix">
 {% highlight sh %}
 cp -r ../openshiftapp/.openshift .
 cp ../openshiftapp/config/database.yml config

--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -29,7 +29,7 @@ First, let's open a terminal:
 Next, type these commands in the terminal:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 mkdir projects
 {% endhighlight %}
@@ -125,7 +125,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser. You should 
 Notice in this window the command prompt is not visible because you are now in the Rails server, the command prompt looks like this:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 $
 {% endhighlight %}
@@ -150,7 +150,7 @@ We're going to use Rails' scaffold functionality to generate a starting point th
 **Coach:** What is Rails scaffolding? (Explain the command, the model name and related database table, naming conventions, attributes and types, etc.) What are migrations and why do you need them?
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 {% endhighlight %}
@@ -166,7 +166,7 @@ rails generate scaffold idea name:string description:text picture:string
 The scaffold creates new files in your project directory, but to get it to work properly we need to run a couple of other commands to update our database and restart the server.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 rails db:migrate
 rails server

--- a/_posts/2014-05-29-touristic-autism_basic-app.markdown
+++ b/_posts/2014-05-29-touristic-autism_basic-app.markdown
@@ -33,7 +33,7 @@ First, let's open a terminal:
 Next, type these commands in the terminal:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 mkdir projects
 {% endhighlight %}
@@ -117,7 +117,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser. You should 
 Notice in this window the command prompt is not visible because you are now in the Rails server, the command prompt looks like this:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 $
 {% endhighlight %}

--- a/_posts/2014-05-29-touristic-autism_continuous-deployment.markdown
+++ b/_posts/2014-05-29-touristic-autism_continuous-deployment.markdown
@@ -22,7 +22,7 @@ OpenShift is one of the cloud deployment services offering such facilities. It i
 [Create an OpenShift Online account](https://openshift.redhat.com/app/account/new?web_user[promo_code]=railsgirls), which allows you to put three apps online for free. Once you are signed up, install the OpenShift RHC Client Tools by adding the rhc gem in the production environment. Add the following to the Gemfiile (which is written in Ruby ndr):
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
       group :production do
         gem 'rhc'
@@ -35,7 +35,7 @@ If you are not using RVM or RailsInstaller then follow [this guide](https://www.
 Then run in the terminal:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
   bundle install --without production
   rhc setup
@@ -54,7 +54,7 @@ Because the only gems we’ve added are restricted to a production environment, 
 Navigate to the "projects" folder. Run in the prompt:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 rhc app create openshiftapp ruby-1.9 postgresql-9.2 --from-code=https://github.com/openshift/rails-example.git
 {% endhighlight %}
@@ -64,7 +64,7 @@ rhc app create openshiftapp ruby-1.9 postgresql-9.2 --from-code=https://github.c
 We need the .openshift directory and config/database.yml file from the sample application in order for our Rails app to run on OpenShift. Copy these from the openshiftapp directory to the railsgirls directory.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 cd railsgirls-galway-2014 
 cp -r ../openshiftapp/.openshift .
@@ -77,7 +77,7 @@ Now add and commit in Git the new changes!
 OpenShift uses the PostgreSQL database, which means that we need to add the pg gem in the production environment to allow Rails to talk to Postgres. Note also the addition of the rails_12factor gem, which is used to serve static assets such as images and stylesheets. Substitute "gem sqlite" in Gemfile with the following:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 gem 'sqlite3', :group => [:development, :test]
 gem 'pg', :group => [:production]
@@ -97,7 +97,7 @@ Add and commit your changes in Git
 We are now ready to deploy the Rails Girls app to OpenShift. We need to tell our Git repository where to push the code. To get the location of your OpenShift code repository, run the following command, and copy the Git URL from the output.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
        rhc app show openshiftapp
 {% endhighlight %}
@@ -107,7 +107,7 @@ We are now ready to deploy the Rails Girls app to OpenShift. We need to tell our
 Now run the following commands, replacing the SSH string with your Git URL. We are using ‘-f’ for force here because we are happy to wipe away the history of the current OpenShift repository, which contains the sample Rails app. When you are pushing future changes, you can just use ‘git push’.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 git remote add openshift ssh://5387bff65973cadf3c000323@openshiftapp-railsgirlsgalway.rhcloud.com/~/git/openshiftapp.git/
 git push -f --set-upstream openshift master
@@ -119,7 +119,7 @@ Get a secret with "rake secret" assign it to the environment variable 'SECRET_KE
 OpenShift (but also Heroku) needs to serve static assets like images and CSS:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 $ rake assets:precompile
 $ git add .
@@ -136,7 +136,7 @@ When we push a new version of the application, anything stored within OpenShift�
 To change the location of the production log, open config/environments/production.rb. Beneath the comment line:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 {% endhighlight %}
@@ -146,7 +146,7 @@ config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 Add the line:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 config.logger = ActiveSupport::Logger.new(File.join(ENV['OPENSHIFT_RUBY_LOG_DIR'], "production.log"))
 {% endhighlight %}

--- a/_posts/2014-05-29-touristic-autism_git.markdown
+++ b/_posts/2014-05-29-touristic-autism_git.markdown
@@ -14,7 +14,7 @@ The basic guides that have been merged and adapted are the [Ruby on Rails Tutori
 Navigate to the root directory of the first app and initialize a new repository:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
       $ git init
     {% endhighlight %}
@@ -24,7 +24,7 @@ Navigate to the root directory of the first app and initialize a new repository:
 Before adding the project to the repository, let's tell Git which files to ignore - because too frequently subject to changes - by listing them in the .gitignore file. The "rails new" command already create a .gitignore file but let's extend it with the following.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 # Ignore other unneeded files.
 database.yml
@@ -44,7 +44,7 @@ doc/
 
 Add the changes (recursively adding every sub-directory, too).
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 git add . 
   {% endhighlight %}
@@ -54,7 +54,7 @@ git add .
 The "git add" command adds the project files to a staging area, which contains pending changes to your projectbu; you can see which files are in the staging area using the status command:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 $ git status
   {% endhighlight %}
@@ -63,7 +63,7 @@ $ git status
 
 Now commit the changes while justifying them with a message:
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 $ git commit -m "Initialize repository"
   {% endhighlight %}
@@ -76,7 +76,7 @@ Now we want our changes to be pushed from our local machine to a remote reposito
 Push up your local changes to the remote repository as follows:
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
     {% highlight sh %}
 $ git remote add origin https://github.com/<username>/railsgirls-galway-2014.git
 $ git push -u origin master

--- a/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
+++ b/_posts/2014-05-29-touristic-autism_resource-modeling.markdown
@@ -126,7 +126,7 @@ Let's add-commit-push to your GitHub repo! See how nicely all the changes are no
 We now use Rails' scaffold functionality to generate and set up all that is necessary to list, add, remove, edit, and view our second resource: "touristic places".
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 rails generate scaffold place name:string address:string latitude:decimal longitude:decimal description:text picture:string user_id:integer
 {% endhighlight %}
@@ -138,7 +138,7 @@ The scaffold creates new files in your project directory. However, we have defin
 We are already using a database (see `gem 'sqlite'` in your Gemfile). Let's add the structure of "place" as a table to our database with the following.
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 bin/rails db:migrate
 {% endhighlight %}
@@ -270,7 +270,7 @@ That's it. Now view a user you have inserted to your application and there you s
 Just as well as we created a "place" resource and associated it with users, we can create a "comment" resource and associate it with places 9and with its author).
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
 rails generate scaffold comment body:text user_id:integer place_id:integer
 bin/rails db:migrate
@@ -405,7 +405,7 @@ Then let's add a constraint over the length of the comment's body field (we'll u
 Open app/models/comment.rb and add between 'class' and 'end':
 
 <div class="os-specific">
-  <div class="nix">
+  <div class="mac nix">
 {% highlight sh %}
   validates :body, length: { maximum: 140 }
 {% endhighlight %}

--- a/js/guides.js
+++ b/js/guides.js
@@ -16,8 +16,11 @@ function loadOs() {
 
 function detectOs() {
   try {
-    if (navigator.appVersion.match(/Win/i)) {
+    var browserVersion = navigator.appVersion;
+    if (browserVersion.match(/Win/i)) {
       return "win";
+    } else if (browserVersion.match(/Macintosh/i)) {
+      return "mac";
     } else {
       return "nix";
     }
@@ -33,13 +36,30 @@ function addIcons() {
 }
 
 function initializeOsSwitchers() {
-  $(".os-specific").prepend("<span class='picker'>Choose your operating system: <a href='#' class='win-link'>Windows</a> | <a href='#' class='nix-link'>Mac/Linux</a></span>").find(".win-link").click(function(event) {
+  var osInstructions = $(".os-specific");
+  var switcher = osInstructions.prepend(
+    "<span class='picker'>Choose your operating system: " +
+      "<a href='#' class='win-link'>Windows</a> | " +
+      "<a href='#' class='mac-link'>Mac</a> | " +
+      "<a href='#' class='nix-link'>Linux</a> " +
+    "</span>"
+  );
+
+  switcher.find(".win-link").click(function(event) {
     event.preventDefault();
     saveOs("win");
 
     $(".os-specific .win-link").addClass("active").siblings().removeClass("active");
     $(".os-specific").children("div").hide().filter(".win").show();
-  }).end().find(".nix-link").click(function(event) {
+  });
+  switcher.find(".mac-link").click(function(event) {
+    event.preventDefault();
+    saveOs("mac");
+
+    $(".os-specific .mac-link").addClass("active").siblings().removeClass("active");
+    $(".os-specific").children("div").hide().filter(".mac").show();
+  });
+  switcher.find(".nix-link").click(function(event) {
     event.preventDefault();
     saveOs("nix");
 


### PR DESCRIPTION
Add Mac/macOS as its own option in the Operating System switcher. Sometimes the instructions for Linux and Mac a just a bit different and it would help to have a separate tab with instructions for Mac.

For pages that have no specific Mac instructions, adding the `mac` class to the `nix` instructions div-element is enough to make it work for both Operating Systems.

![image](https://user-images.githubusercontent.com/282402/217939502-3bdb4b95-3893-4339-8fcd-1f5f51ae541c.png)


Based on PR #503