### PR TITLE
Add GitHub authentication instructions, resolves #505

### DIFF
--- a/_pages/github.md
+++ b/_pages/github.md
@@ -115,7 +115,7 @@ This step creates a Git _remote_, a _connection_, named "origin" pointing to the
 
 Next you need to [create the PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). 
 
-You can access your GitHub personal access tokens here: https://github.com/settings/tokens. Or, when you are logged in to GitHub, you can start on any page and click on your avatar in the top right. Then click "Settings", then "Developer settings", then "Personal access tokens", then "Tokens (classic)".
+You can access your GitHub personal access tokens here: <https://github.com/settings/tokens>. Or, when you are logged in to GitHub, you can start on any page and click on your avatar in the top right. Then click "Settings", then "Developer settings", then "Personal access tokens", then "Tokens (classic)".
 
 Once you are on the "Personal access tokens (classic)" page, click on the "Generate new token" dropdown menu and select "Generate new token (classic)". If you have set up two-factor authentication in your GitHub account, you will need to 2FA authenticate now. 
 
@@ -127,11 +127,11 @@ Click "Generate token" at the bottom of the page.
 
 On the next page you'll see your PAT. This is the only time you'll have access to it, so don't click away from this page until you have completed the _push_ step in the next section. 
 
-Copy and save the PAT token, ideally in a secure password manager. Be careful not to copy and spaces before or after the token -- you can use the two-squares copy button at the end of the token to be certain. You can keep the browser window open until you've completed the next step.
+Copy and save the PAT token, ideally in a secure password manager. Be careful not to copy any spaces before or after the token -- you can use the two-squares copy button at the end of the token to be certain. You can keep the browser window open until you've completed the next step.
 
 ## Push your app to GitHub using the command line (part 2)
 
-Now we want to _push_ to local changes in the Git repository to repository on GitHub with the following command in your terminal.
+Now we want to _push_ the local changes in the Git repository to the repository on GitHub with the following command in your terminal.
 
 {% highlight sh %}
 git push -u origin master
@@ -144,10 +144,10 @@ Username: <your GitHub username>
 Password: <paste in your personal access token>
 {% endhighlight %}
 
-You will need your PAT every time you want to push your code, or you can save the PAT in your computer. This process varies per operating system, so your coach can help you with this process if you plan to keep pushing your code to GitHub. 
+You may need your PAT every time you want to push your code, or you can save the PAT on your computer. This process varies per operating system, so your coach can help you with this process if you plan to keep pushing your code to GitHub.
 
 {% coach %}
-Please help with caching the PAT, if the participants wants to. Find the latest guide for their operating system, or check out a guide like [this](https://mgimond.github.io/Colby-summer-git-workshop-2021/authenticating-with-github.html#saving-tokens-in-windows)
+Please help with caching the PAT, if the participants wants to. Find the latest guide for their operating system, or check out this guide for [storing the PAT on different Operating Systems](https://mgimond.github.io/Colby-summer-git-workshop-2021/authenticating-with-github.html#saving-tokens-in-windows).
 {% endcoach %}
 
 Congratulations your app is on GitHub! Refresh the page in the Browser and you should see a bunch of files there now.

--- a/_pages/github.md
+++ b/_pages/github.md
@@ -90,8 +90,6 @@ Visit the [GitHub website](https://github.com) and create an account or login if
 
 ## Securely sharing your code with GitHub
 
-Previously, you could use a username and password to authenticate your connection to your GitHub remote repository. Now, GitHub requires a more complicated, but more secure, way to authenticate who is accessing your code on their site.
-
 The easiest method for managing authentication is creating a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) that will have matching parts stored on your computer and also on the GitHub site.
 
 Because you are trying to get the code on your computer into your account on the GitHub website, you'll need to connect via the internet. GitHub offers connections over HTTPS and SSH. Using a Personal Access Token (PAT) requires that you use an HTTPS connection. This will be important in the next section, when you'll create your PAT. 

--- a/_pages/github.md
+++ b/_pages/github.md
@@ -47,7 +47,7 @@ After installing or upgrading, run the `git --version` command again to make sur
 
 Once we're sure Git is installed, we can set up our local profile in Git. This profile will be used to describe who made the changes to files we'll store in Git. You can see who made which change and when.
 
-Change "your name" and "your email" with your name and your email address. You can also use a nickname or an alias if you want to use your real name and email address. Be aware: the name and email address you configure here will be visible to others!
+Change "your name" and "your email" with your name and your email address. You can also use a nickname or an alias if you don't want to use your real name and email address. Be aware: the name and email address you configure here will be visible to others!
 
 {% highlight sh %}
 git config --global user.name "your-name"
@@ -84,38 +84,79 @@ git commit -m "First commit"
 
 ## Create a GitHub account
 
-GitHub is a free online code sharing platform. It is a _hub_ for source code saved in _Git_. We will use this to save and share our apps source code.
+GitHub is a free, online, code-sharing platform. It is a _hub_ for source code saved in _Git_. We will use this to save and share our app's source code.
 
-Visit the [GitHub website](https://github.com) and create an account or login if you already have one.
+Visit the [GitHub website](https://github.com) and create an account or login if you already have an account at Github.
 
-## Push your app to GitHub using the command line
+## Securely sharing your code with GitHub
 
-You can now push (Git terminology for _upload_) your saved work to GitHub and share it with others.
+Previously, you could use a username and password to authenticate your connection to your GitHub remote repository. Now, GitHub requires a more complicated, but more secure, way to authenticate who is accessing your code on their site.
+
+The easiest method for managing authentication is creating a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) that will have matching parts stored on your computer and also on the GitHub site.
+
+Because you are trying to get the code on your computer into your account on the GitHub website, you'll need to connect via the internet. GitHub offers connections over HTTPS and SSH. Using a Personal Access Token (PAT) requires that you use an HTTPS connection. This will be important in the next section, when you'll create your PAT. 
+
+## Push your app to GitHub using the command line (part 1)
+
+Now that you have a GitHub account, you can push (Git terminology for _upload_) your saved work to GitHub and share it with others.
 
 Once signed in to GitHub, click on the plus icon (`+`) in the top right corner of the navigation bar. In the dropdown, choose "New repository".
 Having trouble finding the right link? Visit this [new repository page](https://github.com/new) directly.
 
 On the "Create a new repository" page, enter a repository name (like "railsgirls"), choose "public" for the repository's visibility and click the "Create repository" button. Leave the rest of the form untouched.
 
-The next page will list the repository URL we will need to tell Git where to push your app's source code to. In the instructions on the page, find the line that starts with `git remote add origin`. Copy the entire line and paste it into the Terminal app. Then press enter.
+The next page will list the repository URL we will need to tell Git where to push your app's source code to. 
+
+Be certain you are viewing the instructions for HTTPS, so that it will work with the PAT. In the top "Quick setup" section, click on the "HTTPS" button if it is not already selected, and see that all the instructions change the links to start with `https`.
+
+You should use the "push an existing repository from the command line" instructions. Within that section, find the line that starts with `git remote add origin`. Copy the entire line and paste it into the Terminal app. Then press enter.
 
 This step creates a Git _remote_, a _connection_, named "origin" pointing to the GitHub repository you just created in the local repository.
 
-Now we want to _push_ to local changes in the Git repository to repository on GitHub with the following command.
+## Create the Personal Access Token
+
+Next you need to [create the PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). 
+
+You can access your GitHub personal access tokens here: https://github.com/settings/tokens. Or, when you are logged in to GitHub, you can start on any page and click on your avatar in the top right. Then click "Settings", then "Developer settings", then "Personal access tokens", then "Tokens (classic)".
+
+Once you are on the "Personal access tokens (classic)" page, click on the "Generate new token" dropdown menu and select "Generate new token (classic)". If you have set up two-factor authentication in your GitHub account, you will need to 2FA authenticate now. 
+
+When you can see the "New personal access token (classic)" form, use the "Note" to describe this repo (e.g. "RailsGirls") and then select an expiration date. (If you plan to use this project beyond the expiration date, you'll need to repeat these steps when the PAT expires.)
+
+Then, for scopes, select the top "repo" checkbox, that gives the PAT "Full control of private repositories".
+
+Click "Generate token" at the bottom of the page.
+
+On the next page you'll see your PAT. This is the only time you'll have access to it, so don't click away from this page until you have completed the _push_ step in the next section. 
+
+Copy and save the PAT token, ideally in a secure password manager. Be careful not to copy and spaces before or after the token -- you can use the two-squares copy button at the end of the token to be certain. You can keep the browser window open until you've completed the next step.
+
+## Push your app to GitHub using the command line (part 2)
+
+Now we want to _push_ to local changes in the Git repository to repository on GitHub with the following command in your terminal.
 
 {% highlight sh %}
 git push -u origin master
 {% endhighlight %}
 
+When the authentication prompt appears in your terminal, use your PAT as the password, example below. Note that when you paste your PAT in the password, it will not show. Don't paste again, or you will be entering the token twice.
+
+{% highlight sh %}
+Username: <your GitHub username>
+Password: <paste in your personal access token>
+{% endhighlight %}
+
+You will need your PAT every time you want to push your code, or you can save the PAT in your computer. This process varies per operating system, so your coach can help you with this process if you plan to keep pushing your code to GitHub. 
+
 {% coach %}
-Please help with setting up GitHub authentication if the `git push` command fails. Either use an [SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+Please help with caching the PAT, if the participants wants to. Find the latest guide for their operating system, or check out a guide like [this](https://mgimond.github.io/Colby-summer-git-workshop-2021/authenticating-with-github.html#saving-tokens-in-windows)
 {% endcoach %}
 
 Congratulations your app is on GitHub! Refresh the page in the Browser and you should see a bunch of files there now.
 
 ## Saving more changes in Git
 
-If you want to continue making changes and pushing them to GitHub you'll just need to use the following three commands.
+If you want to continue making changes and pushing them to GitHub you'll need to use the following three commands.
 
 Add changes you want to save in Git to the _staging area_:
 


### PR DESCRIPTION
Resolving #505, this adds instructions for authenticating using a Personal Access Token to the GitHub page.

It keeps as much of the current instructions in tact as possible, while splitting the push process into two parts.

Caching the PAT has been reserved for a coaches highlight, as I think it is more advanced than the rest of the day and an unnecessary deep dive.