### PR TITLE
fix path of "Introduction to Ruby"

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ title: Guides
 <p>Learn more topics with these Rails Girls guides. These are not in any particular order. Choose a guide that sounds interesting and try it out!</p>
 <ul class="guides-list">
   <li>
-    <a href="/intro-ruby">
+    <a href="/ruby-intro">
       <span class="guide-icon guide-icon-other"></span>
       <h3>Introduction to Ruby</h3>
     </a>


### PR DESCRIPTION
`/intro-ruby` is not found. so, I fixed.

https://guides.railsgirls.com/ruby-intro is a good tutorial! :)