### PR TITLE
Fix the URL schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ description: "Learn how to make your first web app with Ruby on Rails! Sign up f
 <div class="guides-intro columns">
   <div class="column column-60">
     <h1>Rails Girls Guides</h1>
-    <p>These guides are built to provide tools and a community for women to understand technology and how to build their ideas. Organize your own events, submit new guides, or just use them to learn Rails. For more, add yourself to the <a href="http://groups.google.com/group/rails-girls-team">team mailing list</a>.</p>
+    <p>These guides are built to provide tools and a community for women to understand technology and how to build their ideas. Organize your own events, submit new guides, or just use them to learn Rails. For more, add yourself to the <a href="https://groups.google.com/group/rails-girls-team">team mailing list</a>.</p>
     <p>Want to learn more about <a href="http://railsgirls.com">Rails Girls events?</a></p>
     <p><em>Are you a coach or looking to organize a workshop? Have a look at the <a href="#guides-guides">Guides about Rails Girls</a>.</em></p>
 


### PR DESCRIPTION
This is a tiny fix.
I think Google Groups expects to specify `https` as the schema.
(I know Google redirects HTTP to HTTPS)